### PR TITLE
Add Fedora and CentOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ Windows nightly builds from [here](https://eion.robbmob.com/libdiscord.dll)
 
 The plugin requires libjson-glib which can be downloaded [from github](https://github.com/EionRobb/skype4pidgin/raw/master/skypeweb/libjson-glib-1.0.dll) and copied to the Program Files\Pidgin folder (not the plugins subfolder)
 
+Fedora
+---------
+On Fedora you can install [package](https://apps.fedoraproject.org/packages/purple-discord) from Fedora's main repository:
+```
+	sudo dnf install purple-discord pidgin-discord
+```
+
+CentOS/RHEL
+---------
+On CentOS/RHEL you can install [package](https://apps.fedoraproject.org/packages/purple-discord) from Fedora's [EPEL7](http://fedoraproject.org/wiki/EPEL) repository:
+
+```
+	sudo yum install purple-discord pidgin-discord
+```
+
 Compiling
 ---------
 Requires devel headers/libs for libpurple and libjson-glib [libglib2.0-dev, libjson-glib-dev and libpurple-dev]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The plugin requires libjson-glib which can be downloaded [from github](https://g
 Fedora
 ---------
 On Fedora you can install [package](https://apps.fedoraproject.org/packages/purple-discord) from Fedora's main repository:
-```
+```bash
 	sudo dnf install purple-discord pidgin-discord
 ```
 
@@ -19,14 +19,14 @@ CentOS/RHEL
 ---------
 On CentOS/RHEL you can install [package](https://apps.fedoraproject.org/packages/purple-discord) from Fedora's [EPEL7](http://fedoraproject.org/wiki/EPEL) repository:
 
-```
+```bash
 	sudo yum install purple-discord pidgin-discord
 ```
 
 Compiling
 ---------
 Requires devel headers/libs for libpurple and libjson-glib [libglib2.0-dev, libjson-glib-dev and libpurple-dev]
-```	
+```bash
 	git clone git://github.com/EionRobb/purple-discord.git
 	cd purple-discord
 	make


### PR DESCRIPTION
Purple-discord package is now available at Fedora's main repository. Added Fedora and CentOS installation instructions.