### PR TITLE
Create data structures for all objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,3 +112,6 @@ FAILNOPURPLE:
 clean:
 	rm -f $(DISCORD_TARGET) 
 
+gdb:
+	gdb --args pidgin -c ~/.fake_purple -n -m
+

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 PLUGIN_VERSION ?= 0.9.$(shell date +%Y.%m.%d)
 endif
 
-CFLAGS	?= -O2 -g -pipe -Wall -DDISCORD_PLUGIN_VERSION='"$(PLUGIN_VERSION)"'
+CFLAGS	?= -std=c99 -O2 -g -pipe -Wall -DDISCORD_PLUGIN_VERSION='"$(PLUGIN_VERSION)"'
 LDFLAGS ?= -Wl,-z,relro 
 
 # Do some nasty OS and purple version detection

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -268,6 +268,8 @@ purple_message_destroy(PurpleMessage *message)
 #define PURPLE_MESSAGE_REMOTE_SEND  0x10000
 #endif
 
+#define IGNORE_PRINTS
+
 static GRegex *channel_mentions_regex = NULL;
 
 typedef enum{
@@ -690,6 +692,9 @@ static void discord_print_permission_override(GString *buffer, GHashTable *permi
 
 static void discord_print_guilds(GHashTable *guilds)
 {
+	#ifdef IGNORE_PRINTS
+		return;
+	#endif
 	GString *buffer = g_string_new("\n");
 	GString *row_buffer = g_string_new("");
 	GHashTableIter guild_iter, channel_iter, role_iter;
@@ -745,6 +750,9 @@ static void discord_print_guilds(GHashTable *guilds)
 
 static void discord_print_users(GHashTable *users)
 {
+	#ifdef IGNORE_PRINTS
+		return;
+	#endif
 	GString *buffer = g_string_new("\n");
 	GString *row_buffer = g_string_new("");
 	GHashTableIter user_iter, guild_membership_iter;

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3238,15 +3238,11 @@ discord_chat_set_topic(PurpleConnection *pc, int id, const char *topic)
 	//{"name":"test","position":1,"topic":"new topic","bitrate":64000,"user_limit":0}
 }
 
-typedef struct {
-	gchar *username;
-	gchar *avatar_id;
-} DiscordBuddyAvatar;
-
 static void
 discord_got_avatar(DiscordAccount *ya, JsonNode *node, gpointer user_data)
 {
-	DiscordBuddyAvatar *dba = user_data;
+	DiscordUser *user = user_data;
+	gchar *username = discord_create_fullname(user);
 
 	if (node != NULL) {
 		JsonObject *response = json_node_get_object(node);
@@ -3258,41 +3254,29 @@ discord_got_avatar(DiscordAccount *ya, JsonNode *node, gpointer user_data)
 		response_len = json_object_get_int_member(response, "len");
 		response_dup = g_memdup(response_str, response_len);
 
-		purple_buddy_icons_set_for_user(ya->account, dba->username, response_dup, response_len, dba->avatar_id);
+		purple_buddy_icons_set_for_user(ya->account, username, response_dup, response_len, user->avatar);
 	}
-
-	g_free(dba->username);
-	g_free(dba->avatar_id);
-	g_free(dba);
 }
 
 static void
 discord_get_avatar(DiscordAccount *da, DiscordUser *user)
 {
-	DiscordBuddyAvatar *dba;
-	GString *url;
-	const gchar *checksum;
-
 	if(!user) {
 		return;
 	}
 	gchar *username = discord_create_fullname(user);
-	checksum = purple_buddy_icons_get_checksum_for_user(purple_blist_find_buddy(da->account, username));
+	const gchar *checksum = purple_buddy_icons_get_checksum_for_user(purple_blist_find_buddy(da->account, username));
+	g_free(username);
 	if (purple_strequal(checksum, user->avatar)) {
-		g_free(username);
 		return;
 	}
-
-	dba = g_new0(DiscordBuddyAvatar, 1);
-	dba->username = username;
-	dba->avatar_id = g_strdup(user->avatar);
-
-	url = g_string_new("https://cdn.discordapp.com/avatars/");
+	
+	GString *url = g_string_new("https://cdn.discordapp.com/avatars/");
 	g_string_append_printf(url, "%lu", user->id);
 	g_string_append_c(url, '/');
 	g_string_append_printf(url, "%s", purple_url_encode(user->avatar));
 
-	discord_fetch_url(da, url->str, NULL, discord_got_avatar, dba);
+	discord_fetch_url(da, url->str, NULL, discord_got_avatar, user);
 
 	g_string_free(url, TRUE);
 }

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -706,7 +706,8 @@ static DiscordChannel *discord_get_channel_global_name(DiscordAccount *da, const
 
 	g_hash_table_iter_init(&guild_iter, da->new_guilds);
 	while(g_hash_table_iter_next(&guild_iter, &key, &value)){
-		g_hash_table_iter_init(&channel_iter, da->new_guilds);
+		DiscordGuild *guild = value;
+		g_hash_table_iter_init(&channel_iter, guild->channels);
 		while(g_hash_table_iter_next(&channel_iter, &key, &value)){
 			DiscordChannel *channel = value;
 			if(purple_strequal(name, channel->name)){
@@ -2649,7 +2650,7 @@ str_is_number(const gchar *str)
 	return TRUE;
 }
 
-static GHashTable *
+static __attribute__((optimize("O0"))) GHashTable *
 discord_chat_info_defaults(PurpleConnection *pc, const char *chatname)
 {
 	DiscordAccount *da = purple_connection_get_protocol_data(pc);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -676,8 +676,8 @@ static void discord_print_guilds(GHashTable *guilds)
 				DiscordPermissionOverride *permission_override = value;
 								     
 				discord_print_append(3, buffer, row_buffer, "Override id: %lu", permission_override->id);
-				discord_print_append(3, buffer, row_buffer, "Allow: %lu", permission_override->allow);
-				discord_print_append(3, buffer, row_buffer, "Deny: %lu", permission_override->deny);
+				discord_print_append(4, buffer, row_buffer, "Allow: %lu", permission_override->allow);
+				discord_print_append(4, buffer, row_buffer, "Deny: %lu", permission_override->deny);
 
 			}
 			
@@ -687,8 +687,8 @@ static void discord_print_guilds(GHashTable *guilds)
 				DiscordPermissionOverride *permission_override = value;
 								     
 				discord_print_append(3, buffer, row_buffer, "Override id: %lu", permission_override->id);
-				discord_print_append(3, buffer, row_buffer, "Allow: %lu", permission_override->allow);
-				discord_print_append(3, buffer, row_buffer, "Deny: %lu", permission_override->deny);
+				discord_print_append(4, buffer, row_buffer, "Allow: %lu", permission_override->allow);
+				discord_print_append(4, buffer, row_buffer, "Deny: %lu", permission_override->deny);
 
 			}
 

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -593,7 +593,7 @@ static DiscordPermissionOverride *discord_add_permission_override(DiscordChannel
 	DiscordPermissionOverride *permission_override = discord_new_permission_override(json);
 	gboolean is_role = discord_permission_is_role(json);
 	GHashTable *overrides = is_role ? channel->permission_role_overrides : channel->permission_user_overrides;
-	g_hash_table_replace_int64(overrides, permission_override->id, permission_override);
+	g_hash_table_insert_int64(overrides, permission_override->id, permission_override);
 	return permission_override;
 }
 


### PR DESCRIPTION
* Mirror the data structures of Discord objects from the API so as to be able to access all info
* Switch to using int64's for IDs internally, instead of using the string values we receive from the server - reduces memory usage, even for large guilds/servers
* Add some additional debugging
* Clean up whitespace
* Might need fixes for win32 compat