### PR TITLE
Improve channel mentions

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1280,10 +1280,10 @@ discord_replace_channel(const GMatchInfo *match, GString *result, gpointer user_
 		//TODO make this a clickable link
 		guild = discord_get_guild_int(da, channel->guild_id);
 		if (guild) {
-		    g_string_append_printf(result, discord_normalise_room_name(guild->name, channel->name));
-        } else {
-		    g_string_append_printf(result, "#%s", channel->name);
-        }
+			g_string_append_printf(result, discord_normalise_room_name(guild->name, channel->name));
+		} else {
+			g_string_append_printf(result, "#%s", channel->name);
+		}
 	} else {
 		g_string_append(result, match_string);
 	}

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1275,7 +1275,7 @@ discord_replace_channel(const GMatchInfo *match, GString *result, gpointer user_
 
 	if (channel_name) {
 		//TODO make this a clickable link
-		g_string_append_printf(result, "%s", channel_name);
+		g_string_append_printf(result, "#%s", channel_name);
 	} else {
 		g_string_append(result, match_string);
 	}


### PR DESCRIPTION
Improve channel mentions by including the guild name and using `discord_normalise_room_name`. If the guild name isn't available for some reason, just have `#` followed by the channel name.

This also fixes a crash when the client receives a channel mention with an unknown channel id.