### PR TITLE
Fetch direct messages on connect

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2302,10 +2302,15 @@ discord_got_guilds(DiscordAccount *da, JsonNode *node, gpointer user_data)
 	discord_socket_write_json(da, obj);
 }
 
+/* If count is explicitly specified, use a static request (DMs).
+ * If it is not, use a dynamic request (rooms).
+ * TODO: Possible edge case if there are over 100 incoming DMs?
+ */
+
 static void
 discord_get_history(DiscordAccount *da, const gchar *channel, const gchar *last, int count)
 {
-	gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/v6/channels/%s/messages?limit=%d&around=%s", channel, count ? count : 100, last);
+	gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/v6/channels/%s/messages?limit=%d&after=%s", channel, count ? count : 100, last);
 	discord_fetch_url(da, url, NULL, count ? discord_got_history_static : discord_got_history_of_room, count ? NULL : discord_get_channel_global(da, channel));
 	g_free(url);
 }

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2310,7 +2310,7 @@ discord_got_guilds(DiscordAccount *da, JsonNode *node, gpointer user_data)
 static void
 discord_get_history_dm(DiscordAccount *da, const gchar *channel, const gchar *last, const int mentions)
 {
-	gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/v6/channels/%s/messages?limit=%d&around=%s", channel, mentions + 10, last);
+	gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/v6/channels/%s/messages?limit=%d&around=%s", channel, mentions, last);
 	discord_fetch_url(da, url, NULL, discord_got_history_static, NULL);
 	g_free(url);
 }
@@ -2331,8 +2331,6 @@ discord_got_read_states(DiscordAccount *da, JsonNode *node, gpointer user_data)
 		if(mention_count) {
 			if(g_hash_table_contains(da->one_to_ones, channel)) {
 				gchar *username = g_hash_table_lookup(da->one_to_ones, channel);
-
-				printf("%s sent you %d messages\n", username, mention_count);
 				discord_get_history_dm(da, channel, last_id, mention_count);
 			} else {
 				DiscordChannel *chan = discord_get_channel_global(da, channel);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -789,6 +789,12 @@ static DiscordChannel *discord_get_channel_global(DiscordAccount *da, const gcha
 {
 	return discord_get_channel_global_int(da, to_int(id));
 }
+
+void discord_get_channel_messages(DiscordAccount *da, const gchar* channel_id, const gchar* message_id)
+{
+	printf("%s->%s\n", channel_id, message_id);
+}
+
 //debug
 
 #define discord_print_append(L, B, R, M, D) \
@@ -1362,6 +1368,7 @@ static void discord_create_relationship(DiscordAccount *da, JsonObject *json);
 static void discord_got_relationships(DiscordAccount *da, JsonNode *node, gpointer user_data);
 static void discord_got_private_channels(DiscordAccount *da, JsonNode *node, gpointer user_data);
 static void discord_got_presences(DiscordAccount *da, JsonNode *node, gpointer user_data);
+static void discord_got_read_states(DiscordAccount *da, JsonNode *node, gpointer user_data);
 static void discord_populate_guild(DiscordAccount *da, JsonObject *guild);
 static void discord_got_guilds(DiscordAccount *da, JsonNode *node, gpointer user_data);
 static void discord_got_avatar(DiscordAccount *da, JsonNode *node, gpointer user_data);
@@ -1793,6 +1800,7 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 		discord_got_private_channels(da, json_object_get_member(data, "private_channels"), NULL);
 		discord_got_presences(da, json_object_get_member(data, "presences"), NULL);
 		discord_got_guilds(da, json_object_get_member(data, "guilds"), NULL);
+		discord_got_read_states(da, json_object_get_member(data, "read_state"), NULL);
 
 		purple_connection_set_state(da->pc, PURPLE_CONNECTION_CONNECTED);
 
@@ -2207,6 +2215,7 @@ discord_got_private_channels(DiscordAccount *da, JsonNode *node, gpointer user_d
 		JsonArray *recipients = json_object_get_array_member(channel, "recipients");
 		const gchar *room_id = json_object_get_string_member(channel, "id");
 		gint64 room_type = json_object_get_int_member(channel, "type");
+		const gchar *last_message = json_object_get_string_member(channel, "last_message_id");
 
 		if (room_type == 1) {
 			//One-to-one DM
@@ -2296,6 +2305,37 @@ discord_got_guilds(DiscordAccount *da, JsonNode *node, gpointer user_data)
 	json_object_set_array_member(obj, "d", guild_ids);
 
 	discord_socket_write_json(da, obj);
+}
+
+static void
+discord_got_read_states(DiscordAccount *da, JsonNode *node, gpointer user_data)
+{
+	/* TODO */
+	JsonArray *states = json_node_get_array(node);
+	guint len = json_array_get_length(states);
+
+	printf("Length %d\n", len);
+
+	for(int i = len - 1; i >= 0; i--) {
+		JsonObject *state = json_array_get_object_element(states, i);
+		
+		const gchar *channel = json_object_get_string_member(state, "id");
+		guint mention_count = json_object_get_int_member(state, "mention_count");
+
+		if(mention_count) {
+			DiscordChannel *chan = discord_get_channel_global(da, channel);
+
+			if(!chan) {
+				gchar *username = g_hash_table_lookup(da->one_to_ones, channel);
+
+				printf("%s sent you %d messages\n", username, mention_count);
+			} else if(chan->name) {
+				printf("%d mentions in %s\n", mention_count, chan->name);
+			} else {
+				printf("%d mentions in an unnamed channel?", mention_count);
+			}
+		}
+	}
 }
 
 // static void

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -789,12 +789,6 @@ static DiscordChannel *discord_get_channel_global(DiscordAccount *da, const gcha
 {
 	return discord_get_channel_global_int(da, to_int(id));
 }
-
-void discord_get_channel_messages(DiscordAccount *da, const gchar* channel_id, const gchar* message_id)
-{
-	printf("%s->%s\n", channel_id, message_id);
-}
-
 //debug
 
 #define discord_print_append(L, B, R, M, D) \
@@ -2324,7 +2318,7 @@ discord_got_read_states(DiscordAccount *da, JsonNode *node, gpointer user_data)
 
 	for(int i = len - 1; i >= 0; i--) {
 		JsonObject *state = json_array_get_object_element(states, i);
-		
+
 		const gchar *channel = json_object_get_string_member(state, "id");
 		const gchar *last_id = json_object_get_string_member(state, "last_message_id");
 		guint mentions = json_object_get_int_member(state, "mention_count");

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2327,12 +2327,17 @@ discord_got_read_states(DiscordAccount *da, JsonNode *node, gpointer user_data)
 		
 		const gchar *channel = json_object_get_string_member(state, "id");
 		const gchar *last_id = json_object_get_string_member(state, "last_message_id");
-		guint mention_count = json_object_get_int_member(state, "mention_count");
+		guint mentions = json_object_get_int_member(state, "mention_count");
 
-		if(mention_count) {
-			printf("mention\n");
+		if(mentions) {
 			gboolean isDM = g_hash_table_contains(da->one_to_ones, channel);
-			discord_get_history(da, channel, last_id, isDM ? mention_count * 2 : 0);
+
+			if(isDM) {
+				discord_get_history(da, channel, last_id, mentions * 2);
+			} else {
+				/* TODO: fetch channel history */
+				printf("%d unhandled mentions in channel %s\n", mentions, discord_get_channel_global(da, channel)->name);
+			}
 		}
 	}
 }

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2303,7 +2303,7 @@ discord_got_guilds(DiscordAccount *da, JsonNode *node, gpointer user_data)
 }
 
 static void
-discord_get_history(DiscordAccount *da, const gchar *channel, const gchar *last, const int count)
+discord_get_history(DiscordAccount *da, const gchar *channel, const gchar *last, int count)
 {
 	gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/v6/channels/%s/messages?limit=%d&around=%s", channel, count ? count : 100, last);
 	discord_fetch_url(da, url, NULL, count ? discord_got_history_static : discord_got_history_of_room, count ? NULL : discord_get_channel_global(da, channel));
@@ -2330,7 +2330,7 @@ discord_got_read_states(DiscordAccount *da, JsonNode *node, gpointer user_data)
 				discord_get_history(da, channel, last_id, mentions * 2);
 			} else {
 				/* TODO: fetch channel history */
-				printf("%d unhandled mentions in channel %s\n", mentions, discord_get_channel_global(da, channel)->name);
+				purple_debug_misc("discord", "%d unhandled mentions in channel %s\n", mentions, discord_get_channel_global(da, channel)->name);
 			}
 		}
 	}


### PR DESCRIPTION
This enables direct messaging to work as expected when the user is offline; this also means that for many users, it will not be necessary to use discordapp.com at all to check messages.

Additionally, the same code gets the channels that the user is mentioned in; however, fetching channel history is somewhat more involved and therefore not covered in this patch set. It is currently stubbed out, but prints out the name of the channel with mentions for debugging.