### PR TITLE
Escape markdown correctly

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3616,7 +3616,7 @@ discord_escape_md(gchar* markdown)
 				  		      markdown[i - 1] == ' ' ||
 				  		      markdown[i - 1] == '\0')) ||
 				(c == '*') ||
-				(c == '\\') ||
+				(c == '\\' && markdown[i + 1] != '_') ||
 				(c == '~' && (markdown[i + 1] == '~')))
 			{
 				g_string_append_c(s, '\\');

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3571,12 +3571,21 @@ discord_html_to_markdown(gchar* html)
 static gchar*
 discord_escape_md(gchar* markdown)
 {
-	markdown = discord_helper_replace(markdown, "\\", "\\\\");
-	markdown = discord_helper_replace(markdown, "_", "\\_");
-	markdown = discord_helper_replace(markdown, "*", "\\*");
-	markdown = discord_helper_replace(markdown, "~", "\\~");
+	/* Worst case allocation */
+	GString *s = g_string_sized_new(strlen(markdown) * 2);
 
-	return markdown;
+	gboolean verbatim = TRUE;
+
+	for(int i = 0; i < strlen(markdown); ++i) {
+		/* TODO: Escape iff it is necessary */
+		if(verbatim) {
+			g_string_append_c(s, markdown[i]);
+		}
+	}
+
+	g_free(markdown);
+
+	return g_string_free(s, FALSE);
 }
 
 static gint

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3579,7 +3579,6 @@ discord_escape_md(gchar* markdown)
 	gboolean link = FALSE;
 
 	for(int i = 0; i < strlen(markdown); ++i) {
-		/* TODO: Escape iff it is necessary */
 		char c = markdown[i];
 
 		if(c == '`') {
@@ -3599,8 +3598,11 @@ discord_escape_md(gchar* markdown)
 			}
 		}
 
-		if(!verbatim && strncmp(markdown + i, "http://", sizeof("http://") - 1) == 0) {
-			link = verbatim = TRUE;
+		if(!verbatim) {
+			if(strncmp(markdown + i, "http://", sizeof("http://") - 1) == 0 ||
+			   strncmp(markdown + i, "https://", sizeof("https://") - 1) == 0) 
+
+				link = verbatim = TRUE;
 		}
 
 		if(link && c == ' ') {

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3626,8 +3626,6 @@ discord_escape_md(gchar* markdown)
 		g_string_append_c(s, c);
 	}
 
-	g_free(markdown);
-
 	return g_string_free(s, FALSE);
 }
 
@@ -3645,7 +3643,7 @@ discord_conversation_send_message(DiscordAccount *da, guint64 room_id, const gch
 	nonce = g_strdup_printf("%" G_GUINT32_FORMAT, g_random_int());
 	g_hash_table_insert(da->sent_message_ids, nonce, nonce);
 
-	marked = discord_html_to_markdown(discord_escape_md(g_strdup(message)));
+	marked = discord_html_to_markdown(discord_escape_md(message));
 	stripped = g_strstrip(purple_markup_strip_html(marked));
 
 	/* translate Discord-formatted actions into *markdown* syntax */

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3569,7 +3569,7 @@ discord_html_to_markdown(gchar* html)
 }
 
 static gchar*
-discord_escape_md(gchar* markdown)
+discord_escape_md(const gchar* markdown)
 {
 	/* Worst case allocation */
 	GString *s = g_string_sized_new(strlen(markdown) * 2);


### PR DESCRIPTION
Rather than escaping all markdown special characters, this routine scans the string character-by-character, only inserting backslashes conservatively. This closes #55 