### PR TITLE
Buddy list autopopulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ Requires devel headers/libs for libpurple and libjson-glib [libglib2.0-dev, libj
 	sudo make install
 ```
 
-Where's my rooms?
------------------
-In Pidgin, look in Tools->Room List to get a list of rooms you're in.  It's recommended that you add them to your buddy list and mark them as 'persistent' and 'auto-join'.
-
 Show your appreciation
 ----------------------
 Did this plugin make your life happier?  [Send me $1](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=PZMBF2QVF69GA) to say thanks!

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2291,7 +2291,7 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 		GHashTable *components = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
 		g_hash_table_replace(components, "id", g_strdup_printf("%" G_GUINT64_FORMAT, channel->id));
-		g_hash_table_replace(components, "name", channel->name);
+		g_hash_table_replace(components, "name", g_strdup(channel->name));
 
 		PurpleChat *chat = purple_chat_new(da->account, channel->name, components);
 		purple_blist_add_chat(chat, group, NULL);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2370,8 +2370,8 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 
 		GHashTable *components = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
+		g_hash_table_replace(components, "id", g_strdup_printf("%" G_GUINT64_FORMAT, channel->id));
 		g_hash_table_replace(components, "name", channel->name);
-		g_hash_table_replace(components, "channel_id", g_strdup_printf("%" G_GUINT64_FORMAT, channel->id));
 
 		PurpleChat *chat = purple_chat_new(da->account, channel->name, components);
 

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2277,7 +2277,6 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 	PurpleGroup *group = purple_group_new(guild->name);
 
 	if(!group) {
-		printf("Bad group\n");
 		return;
 	}
 
@@ -2295,10 +2294,8 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 		g_hash_table_replace(components, "name", channel->name);
 
 		PurpleChat *chat = purple_chat_new(da->account, channel->name, components);
-
 		purple_blist_add_chat(chat, group, NULL);
 	}
-
 
 	purple_blist_add_group(group, NULL);
 }

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2387,8 +2387,6 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 		/* Ensure that we actually have permissions for this channel */
 		guint64 permission = discord_compute_permission(da, user, channel);
 
-		printf("Permission for %s: %" G_GUINT64_FORMAT "\n", channel->name, permission);
-
 		/* READ_MESSAGES */
 		if(!(permission & 0x400)) {
 			continue;
@@ -3331,11 +3329,7 @@ static guint64
 discord_permission_role(DiscordGuild *guild, guint64 r, guint64 permission)
 {
 	DiscordGuildRole *role = g_hash_table_lookup_int64(guild->roles, r);
-
-	if(role)
-		return permission | role->permissions;
-
-	return permission;
+	return role ? (permission | role->permissions) : permission;
 }
 
 static guint64
@@ -3344,12 +3338,7 @@ discord_permission_role_override(DiscordChannel *channel, guint64 role, guint64 
 	DiscordPermissionOverride *ro =
 		g_hash_table_lookup_int64(channel->permission_role_overrides, role);
 
-	if(ro) {
-		printf("Allow %lu, deny %lu\n", ro->allow, ro->deny);
-		return (permission & ~(ro->deny)) | ro->allow;
-	}
-
-	return permission;
+	return ro ? ((permission & ~(ro->deny)) | ro->allow) : permission;
 }
 
 static guint64

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -4142,7 +4142,7 @@ plugin_load(PurplePlugin *plugin, GError **error)
 	emoji_regex = g_regex_new("&lt;:([^:]+):(\\d+)&gt;", G_REGEX_OPTIMIZE, 0, NULL);
 	emoji_natural_regex = g_regex_new(":([^:]+):", G_REGEX_OPTIMIZE, 0, NULL);
 	action_star_regex = g_regex_new("^_([^\\*]+)_$", G_REGEX_OPTIMIZE, 0, NULL);
-	mention_regex = g_regex_new("&lt;@(\\d+)&gt;", G_REGEX_OPTIMIZE, 0, NULL);
+	mention_regex = g_regex_new("&lt;@!?(\\d+)&gt;", G_REGEX_OPTIMIZE, 0, NULL);
 	natural_mention_regex = g_regex_new("^([^:]+): ", G_REGEX_OPTIMIZE, 0, NULL);
 
 	// purple_cmd_register("create", "s", PURPLE_CMD_P_PLUGIN, PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_IM |

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1931,7 +1931,9 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 			}
 		}
 
-		discord_buddy_guild(da, guild);
+		if (purple_account_get_bool(da->account, "populate-blist", TRUE)) {
+			discord_buddy_guild(da, guild);
+		}
 
 		purple_debug_info("discord", "Room has '%d' Members\n", json_array_get_length(members));
 
@@ -2442,7 +2444,6 @@ discord_got_guilds(DiscordAccount *da, JsonNode *node, gpointer user_data)
 	for (int i = len - 1; i >= 0; i--) {
 		JsonObject *guild = json_array_get_object_element(guilds, i);
 		discord_populate_guild(da, guild);
-//		discord_buddy_guild(da, discord_get_guild(da, json_object_get_string_member(guild, "id")));
 		json_array_add_string_element(guild_ids, json_object_get_string_member(guild, "id"));
 	}
 
@@ -4153,6 +4154,9 @@ discord_add_account_options(GList *account_options)
 	PurpleAccountOption *option;
 
 	option = purple_account_option_bool_new(N_("Use status message as in-game info"), "use-status-as-game", FALSE);
+	account_options = g_list_append(account_options, option);
+
+	option = purple_account_option_bool_new(N_("Auto-create rooms on buddy list"), "populate-blist", TRUE);
 	account_options = g_list_append(account_options, option);
 
 	return account_options;

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3260,6 +3260,15 @@ discord_compute_permission(DiscordAccount *da, DiscordUser *user, DiscordChannel
 	if(guild_membership) {
 		/* Should always exist, but just in case... */
 
+		DiscordGuild *guild = discord_get_guild_int(da, channel->guild_id);
+
+		for(guint i = 0; i < guild_membership->roles->len; i++) {
+			guint64 r = g_array_index(guild_membership->roles, guint64, i);
+
+			DiscordGuildRole *role = g_hash_table_lookup_int64(guild->roles, r);
+			permissions |= role->permissions;
+		}
+
 		for(guint i = 0; i < guild_membership->roles->len; i++) {
 			guint64 role = g_array_index(guild_membership->roles, guint64, i);
 
@@ -3271,7 +3280,7 @@ discord_compute_permission(DiscordAccount *da, DiscordUser *user, DiscordChannel
 				printf("There is a permission override for role %d:\n", i);
 				printf("Allow %lu, deny %lu\n", ro->allow, ro->deny);
 				printf("%lu", permissions);
-				permissions = (permissions & ~ro->deny) | ro_allow;
+				permissions = (permissions & ~(ro->deny)) | ro->allow;
 				printf("->%lu\n", permissions);
 			}
 		}
@@ -3283,7 +3292,7 @@ discord_compute_permission(DiscordAccount *da, DiscordUser *user, DiscordChannel
 		g_hash_table_lookup_int64(channel->permission_user_overrides, uid);
 
 	if(uo) {
-		permissions = (permissions & ~uo->deny) | uo_allow;
+		permissions = (permissions & ~(uo->deny)) | uo->allow;
 	}
 
 	return permissions;

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -404,6 +404,7 @@ typedef struct {
 	GSList *http_conns; /**< PurpleHttpConnection to be cancelled on logout */
 	gint frames_since_reconnect;
 	GSList *pending_writes;
+	gint roomlist_guild_count;
 } DiscordAccount;
 
 //just in case we optimize...
@@ -2008,6 +2009,84 @@ discord_normalise_room_name(const gchar *guild_name, const gchar *name)
 
 	return old_name;
 }
+
+static void
+discord_roomlist_got_list(DiscordAccount *da, DiscordGuild *guild, gpointer user_data)
+{
+	PurpleRoomlist *roomlist = user_data;
+	PurpleRoomlistRoom *category = purple_roomlist_room_new(PURPLE_ROOMLIST_ROOMTYPE_CATEGORY, guild->name, NULL);
+	purple_roomlist_room_add(roomlist, category);
+
+	GHashTableIter iter;
+	gpointer key, value;
+
+	g_hash_table_iter_init(&iter, guild->channels);
+	while(g_hash_table_iter_next(&iter, &key, &value)){
+		DiscordChannel *channel = value;
+		PurpleRoomlistRoom *room;
+
+		gchar *channel_id = g_strdup_printf("%" G_GUINT64_FORMAT, channel->id);
+		gchar *type_str;
+
+		room = purple_roomlist_room_new(PURPLE_ROOMLIST_ROOMTYPE_ROOM, "", category);
+
+		purple_roomlist_room_add_field(roomlist, room, channel_id);
+		purple_roomlist_room_add_field(roomlist, room, channel->name);
+		switch(channel->type) {
+			case 0: type_str = "Text"; break;
+			case 1: type_str = "Voice"; break;
+			default: type_str = "Unknown"; break;
+		}
+		purple_roomlist_room_add_field(roomlist, room, type_str);
+
+		purple_roomlist_room_add(roomlist, room);
+		g_free(channel_id);
+	}
+}
+
+static gchar *
+discord_roomlist_serialize(PurpleRoomlistRoom *room) {
+	GList *fields = purple_roomlist_room_get_fields(room);
+	const gchar *id = (const gchar *) fields->data;
+
+	return g_strdup(id);
+}
+
+PurpleRoomlist *
+discord_roomlist_get_list(PurpleConnection *pc)
+{
+	DiscordAccount *da = purple_connection_get_protocol_data(pc);
+	PurpleRoomlist *roomlist;
+	GList *fields = NULL;
+	PurpleRoomlistField *f;
+
+	roomlist = purple_roomlist_new(da->account);
+
+	f = purple_roomlist_field_new(PURPLE_ROOMLIST_FIELD_STRING, _("ID"), "id", TRUE);
+	fields = g_list_append(fields, f);
+
+	f = purple_roomlist_field_new(PURPLE_ROOMLIST_FIELD_STRING, _("Name"), "name", FALSE);
+	fields = g_list_append(fields, f);
+
+	f = purple_roomlist_field_new(PURPLE_ROOMLIST_FIELD_STRING, _("Room Type"), "type", FALSE);
+	fields = g_list_append(fields, f);
+
+	purple_roomlist_set_fields(roomlist, fields);
+	purple_roomlist_set_in_progress(roomlist, TRUE);
+
+	GHashTableIter iter;
+	gpointer key, guild;
+
+	g_hash_table_iter_init(&iter, da->new_guilds);
+	while(g_hash_table_iter_next(&iter, &key, &guild)){
+		discord_roomlist_got_list(da, guild, roomlist);
+	}
+
+	purple_roomlist_set_in_progress(roomlist, FALSE);
+
+	return roomlist;
+}
+
 
 void
 discord_set_status(PurpleAccount *account, PurpleStatus *status)
@@ -4317,6 +4396,9 @@ plugin_init(PurplePlugin *plugin)
 	prpl_info->group_buddy = discord_fake_group_buddy;
 	prpl_info->rename_group = discord_fake_group_rename;
 	prpl_info->get_info = discord_get_info;
+
+	prpl_info->roomlist_get_list = discord_roomlist_get_list;
+	prpl_info->roomlist_room_serialize = discord_roomlist_serialize;
 }
 
 static PurplePluginInfo info = {
@@ -4435,6 +4517,13 @@ discord_protocol_client_iface_init(PurpleProtocolClientIface *prpl_info)
 	prpl_info->tooltip_text = discord_tooltip_text;
 }
 
+static void
+discord_protocol_roomlist_iface_init(PurpleProtocolRoomlistIface *prpl_info)
+{
+	prpl_info->get_list = discord_roomlist_get_list;
+	prpl_info->room_serialize = discord_roomlist_serialize;
+}
+
 static PurpleProtocol *discord_protocol;
 
 PURPLE_DEFINE_TYPE_EXTENDED(
@@ -4451,6 +4540,10 @@ PURPLE_DEFINE_TYPE_EXTENDED(
 
 	PURPLE_IMPLEMENT_INTERFACE_STATIC(PURPLE_TYPE_PROTOCOL_CLIENT_IFACE,
 		                          discord_protocol_client_iface_init)
+
+	PURPLE_IMPLEMENT_INTERFACE_STATIC(PURPLE_TYPE_PROTOCOL_ROOMLIST_IFACE,
+		                          discord_protocol_roomlist_iface_init)
+
 );
 
 static gboolean

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3276,9 +3276,8 @@ discord_permission_role_override(DiscordChannel *channel, guint64 role, guint64 
 static guint64
 discord_compute_permission(DiscordAccount *da, DiscordUser *user, DiscordChannel *channel) {
 	guint64 uid = user->id;
-	guint64 permissions = 0; /* Assume recv / send messages */
+	guint64 permissions = 0;
 
-	/* Check overrides for the roles we're in */
 	DiscordGuildMembership *guild_membership
 		= g_hash_table_lookup_int64(user->guild_memberships, channel->guild_id);
 
@@ -3287,10 +3286,15 @@ discord_compute_permission(DiscordAccount *da, DiscordUser *user, DiscordChannel
 
 		DiscordGuild *guild = discord_get_guild_int(da, channel->guild_id);
 
+		/* @everyone */
+		permissions = discord_permission_role(guild, channel->guild_id, permissions);
+
 		for(guint i = 0; i < guild_membership->roles->len; i++) {
 			guint64 r = g_array_index(guild_membership->roles, guint64, i);
 			permissions = discord_permission_role(guild, r, permissions);
 		}
+
+		permissions = discord_permission_role_override(channel, channel->guild_id, permissions);
 
 		for(guint i = 0; i < guild_membership->roles->len; i++) {
 			guint64 role = g_array_index(guild_membership->roles, guint64, i);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2387,10 +2387,11 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 		/* Ensure that we actually have permissions for this channel */
 		guint64 permission = discord_compute_permission(da, user, channel);
 
-		/* READ_MESSAGES */
-		if(!(permission & 0x400)) {
-			continue;
-		}
+		/* must have READ_MESSAGES */
+		if(!(permission & 0x400)) continue;
+
+		/* Drop voice channels since we don't support them anyway */
+		if(channel->type == CHANNEL_VOICE) continue;
 
 		GHashTable *components = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 


### PR DESCRIPTION
* Automatically populate the buddy list with each group representing a server
* Implement permission computation routines
* Prefer this interface which is saner to work with (this closes #53)
* Hide rooms without permission to READ_MESSAGES (this closes #45)
* Hide voice channels

The room list API is deprecated but still included; bitlbee, spectrum2, etc require it.

The major flaw of this code is that it can only create the buddy list groups, not update them. We'll have to figure out a scheme for synchronisation later. As a workaround for the time being, deleting the group and reloading the plugin will sync it.

Another question to consider is handle user aliases, removed chats, etc. Is it possible to disable these changes in the UI?