### PR TITLE
Native nicks

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2175,19 +2175,18 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 		DiscordGuild *guild = discord_get_guild_int(da, to_int(json_object_get_string_member(data, "guild_id")));
 
 		const gchar *new_nick = json_object_get_string_member(data, "nick");
-		gchar *old_nick = g_hash_table_lookup_int64(guild->nicknames, user->id);
+		const gchar *old_nick = g_hash_table_lookup_int64(guild->nicknames, user->id);
 
 		if (!purple_strequal(new_nick, old_nick)) {
 			/* Nick change */
-
-			if(old_nick) {
-				g_hash_table_remove(guild->nicknames_rev, old_nick);
-			}
-
 			gchar *nick = discord_alloc_nickname(user, guild, new_nick);
 
 			/* TODO: Propagate */
 			printf("TODO: Propagate nick change from %s -> %s\n", old_nick, nick);
+
+			if(old_nick) {
+				g_hash_table_remove(guild->nicknames_rev, old_nick);
+			}
 		}
 
 		/* TODO: Track role changes */

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3677,6 +3677,8 @@ discord_got_channel_info(DiscordAccount *da, JsonNode *node, gpointer user_data)
 				users = g_list_prepend(users, nickname);
 				flags = g_list_prepend(flags, GINT_TO_POINTER(cbflags));
 			}
+
+			g_free(full_username);
 		}
 
 		purple_chat_conversation_clear_users(chat);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3341,7 +3341,7 @@ discord_chat_nick(PurpleConnection *pc, int id, gchar *new_nick)
 	gchar *postdata = json_object_to_string(data);
 
 	gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/v6/guilds/%" G_GUINT64_FORMAT "/members/@me/nick", guild->id);
-	discord_fetch_url_with_method(da, "PATCH", "https://" DISCORD_API_SERVER "/api/v6/guilds/ /@me/nick", postdata, NULL, NULL);
+	discord_fetch_url_with_method(da, "PATCH", url, postdata, NULL, NULL);
 
 	g_free(url);
 	g_free(postdata);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1917,20 +1917,24 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 		const gchar *guild_id = json_object_get_string_member(data, "guild_id");
 		gint64 idle_since = json_object_get_int_member(data, "idle_since");
 
+
 		if(guild_id){
 			GHashTableIter iter;
 			gpointer key, value;
 
-			g_hash_table_iter_init(&iter, discord_get_guild(da, guild_id)->channels);
+			DiscordGuild *guild = discord_get_guild_int(da, to_int(guild_id));
+			gchar *nickname = discord_create_nickname(user, guild);
+
+			g_hash_table_iter_init(&iter, guild->channels);
 			while(g_hash_table_iter_next(&iter, &key, &value)){
 				DiscordChannel *channel = value;
 				PurpleChatConversation *chat = purple_conversations_find_chat(da->pc, g_int64_hash(&channel->id));
 				if(chat != NULL){
 					if (user->status == USER_OFFLINE) {
-						purple_chat_conversation_remove_user(chat, username, NULL);
-					} else if (!purple_chat_conversation_has_user(chat, username)) {
-						PurpleChatUserFlags flags = discord_get_user_flags(da, guild_id, username);
-						purple_chat_conversation_add_user(chat, username, NULL, flags, FALSE);
+						purple_chat_conversation_remove_user(chat, nickname, NULL);
+					} else if (!purple_chat_conversation_has_user(chat, nickname)) {
+						PurpleChatUserFlags flags = discord_get_user_flags(da, guild_id, nickname);
+						purple_chat_conversation_add_user(chat, nickname, NULL, flags, FALSE);
 					}
 				}
 			}

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -731,7 +731,7 @@ discord_alloc_nickname(DiscordUser *user, DiscordGuild *guild, const gchar *sugg
 	gchar *nick;
 
 	if(suggested_nick)  {
-		nick = g_strdup(suggested_nick);
+		nick = suggested_nick;
 	} else {
 		nick = user->name;
 	}

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -172,6 +172,7 @@ purple_conversations_find_chat(PurpleConnection *pc, int id)
 #define purple_chat_conversation_remove_user  purple_conv_chat_remove_user
 #define purple_chat_conversation_clear_users  purple_conv_chat_clear_users
 #define purple_chat_conversation_has_user     purple_conv_chat_find_user
+#define purple_chat_conversation_rename_user  purple_conv_chat_rename_user
 #define purple_chat_conversation_get_topic    purple_conv_chat_get_topic
 #define purple_chat_conversation_set_topic    purple_conv_chat_set_topic
 #define PurpleChatUserFlags  PurpleConvChatBuddyFlags

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2128,7 +2128,7 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 			gchar *full_username = discord_create_fullname(user);
 			PurpleChatUserFlags cbflags = discord_get_user_flags(da, guild_id, full_username);
 
-			users = g_list_prepend(users, full_username);
+			users = g_list_prepend(users, discord_create_nickname(user, guild));
 			flags = g_list_prepend(flags, GINT_TO_POINTER(cbflags));
 		}
 

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1953,8 +1953,13 @@ release_ctx:
 static void
 discord_got_nick_change(DiscordAccount *da, DiscordUser *user, DiscordGuild *guild, const gchar *new, const gchar *old, gboolean self)
 {
-	/* Nick change */
 	gchar *old_safe = g_strdup(old);
+
+	if(old) {
+		g_hash_table_remove(guild->nicknames_rev, old);
+	}
+
+	/* Nick change */
 	gchar *nick = discord_alloc_nickname(user, guild, new);
 
 	/* Propagate through the guild, see e.g. irc_msg_nick */
@@ -1971,9 +1976,6 @@ discord_got_nick_change(DiscordAccount *da, DiscordUser *user, DiscordGuild *gui
 		}
 	}
 
-	if(old) {
-		g_hash_table_remove(guild->nicknames_rev, old);
-	}
 }
 
 

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2190,6 +2190,7 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 
 			gchar *full_username = discord_create_fullname(user);
 			PurpleChatUserFlags cbflags = discord_get_user_flags(da, guild_id, full_username);
+			g_free(full_username);
 
 			users = g_list_prepend(users, discord_create_nickname(user, guild));
 			flags = g_list_prepend(flags, GINT_TO_POINTER(cbflags));

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -725,16 +725,10 @@ static gchar *discord_create_fullname(DiscordUser *user)
 
 static gchar * discord_create_nickname(DiscordUser *author, DiscordGuild *guild);
 
-static gchar *
+static const gchar *
 discord_alloc_nickname(DiscordUser *user, DiscordGuild *guild, const gchar *suggested_nick)
 {
-	gchar *nick;
-
-	if(suggested_nick)  {
-		nick = suggested_nick;
-	} else {
-		nick = user->name;
-	}
+	const gchar *nick = suggested_nick ? suggested_nick : user->name;
 
 	/* TODO: Disambiguate if necessary */
 
@@ -1960,7 +1954,7 @@ discord_got_nick_change(DiscordAccount *da, DiscordUser *user, DiscordGuild *gui
 	}
 
 	/* Nick change */
-	gchar *nick = discord_alloc_nickname(user, guild, new);
+	const gchar *nick = discord_alloc_nickname(user, guild, new);
 
 	/* Propagate through the guild, see e.g. irc_msg_nick */
 	GHashTableIter channel_iter;

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1954,6 +1954,7 @@ static void
 discord_got_nick_change(DiscordAccount *da, DiscordUser *user, DiscordGuild *guild, const gchar *new, const gchar *old, gboolean self)
 {
 	/* Nick change */
+	gchar *old_safe = g_strdup(old);
 	gchar *nick = discord_alloc_nickname(user, guild, new);
 
 	/* Propagate through the guild, see e.g. irc_msg_nick */
@@ -1965,8 +1966,8 @@ discord_got_nick_change(DiscordAccount *da, DiscordUser *user, DiscordGuild *gui
 		DiscordChannel *channel = value;
 		PurpleChatConversation *chat = purple_conversations_find_chat(da->pc, g_int64_hash(&channel->id));
 
-		if (purple_chat_conversation_has_user(chat, old) || self) {
-			purple_chat_conversation_rename_user(chat, old, nick);
+		if (purple_chat_conversation_has_user(chat, old_safe)) {
+			purple_chat_conversation_rename_user(chat, old_safe, nick);
 		}
 	}
 

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1474,17 +1474,17 @@ discord_replace_emoji(const GMatchInfo *match, GString *result, gpointer user_da
 	return FALSE;
 }
 
-struct DiscordAG {
-	DiscordAccount *a;
-	DiscordGuild *g;
-};
+typedef struct {
+	DiscordAccount *account;
+	DiscordGuild *guild;
+} DiscordAccountGuild;
 
 static gboolean
 discord_replace_mention(const GMatchInfo *match, GString *result, gpointer user_data)
 {
-	struct DiscordAG *ag = user_data;
-	DiscordAccount *da = ag->a;
-	DiscordGuild *guild = ag->g;
+	DiscordAccountGuild *ag = user_data;
+	DiscordAccount *da = ag->account;
+	DiscordGuild *guild = ag->guild;
 	gchar *match_string = g_match_info_fetch(match, 0);
 
 	gchar *snowflake_str = g_match_info_fetch(match, 1);
@@ -1521,7 +1521,7 @@ discord_replace_mention(const GMatchInfo *match, GString *result, gpointer user_
 static gchar *
 discord_replace_mentions_bare(DiscordAccount *da, DiscordGuild *g, gchar *message)
 {
-	struct DiscordAG ag = { .a = da, .g = g };
+	DiscordAccountGuild ag = { .account = da, .guild = g };
 	gchar *tmp = g_regex_replace_eval(mention_regex, message, -1, 0, 0, discord_replace_mention, &ag, NULL);
 
 	if (tmp != NULL) {
@@ -1535,9 +1535,9 @@ discord_replace_mentions_bare(DiscordAccount *da, DiscordGuild *g, gchar *messag
 static gboolean
 discord_make_mention(const GMatchInfo *match, GString *result, gpointer user_data)
 {
-	struct DiscordAG *ag = user_data;
-	DiscordAccount *da = ag->a;
-	DiscordGuild *guild = ag->g;
+	DiscordAccountGuild *ag = user_data;
+	DiscordAccount *da = ag->account;
+	DiscordGuild *guild = ag->guild;
 
 	gchar *match_string = g_match_info_fetch(match, 0);
 	gchar *identifier = g_match_info_fetch(match, 1);
@@ -1590,7 +1590,7 @@ discord_make_mention(const GMatchInfo *match, GString *result, gpointer user_dat
 static gchar *
 discord_make_mentions(DiscordAccount *da, DiscordGuild *guild, gchar *message)
 {
-	struct DiscordAG ag = { .a = da, .g = guild };
+	DiscordAccountGuild ag = { .account = da, .guild = guild };
 	gchar *tmp = g_regex_replace_eval(natural_mention_regex, message, -1, 0, 0, discord_make_mention, &ag, NULL);
 
 	if (tmp != NULL) {


### PR DESCRIPTION
[Woo! That was a doozy!](http://www.youtube.com/watch?v=PDxjdS2YCVc)

* In guilds, if the user set a nick, use it to display messages instead of the username (this closes #14)
* Conversely, if they have not set a nick, use the username without the discriminator for readability.
* If necessary, disambiguate the name by appending the discriminator or the entire tag.
* Use this name in typing notifications
* Use this name in mentions
* Retain mention support using tags and aliases but also add this name for tab completion
* Define `discord_get_real_name` to map these nicknames back to tags for opening DMs
* Listen to `GUILD_MEMBER_UPDATE` events to track nick changes and propagate these back
* Implement the `/nick` command

Such a large changeset is not without bugs, but I wanted to open the PR anyway for discussion:

* There's a super obscure corner case which causes `/nick` to work on the server but not update locally for the rest of the session.