### PR TITLE
Group DM support (again)

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2172,6 +2172,17 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 		}
 
 		/* TODO: Track role changes */
+	} else if (purple_strequal(type, "CHANNEL_RECIPIENT_ADD") || purple_strequal(type, "CHANNEL_RECIPIENT_REMOVE")) {
+		DiscordUser *user = discord_upsert_user(da->new_users, json_object_get_object_member(data, "user"));
+		gchar *name = discord_create_fullname(user);
+		guint64 room_id = to_int(json_object_get_string_member(data, "channel_id"));
+		PurpleChatConversation *chat = purple_conversations_find_chat(da->pc, g_int64_hash(&room_id));
+
+		if (purple_strequal(type, "CHANNEL_RECIPIENT_ADD")) {
+			purple_chat_conversation_add_user(chat, name, NULL, PURPLE_CHAT_USER_NONE, TRUE);
+		} else {
+			purple_chat_conversation_remove_user(chat, name, NULL);
+		}
 	} else {
 		purple_debug_info("discord", "Unhandled message type '%s'\n", type);
 	}

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1847,9 +1847,9 @@ discord_got_group_dm(DiscordAccount *da, JsonObject *data)
 
 	DiscordChannelType channel_type = CHANNEL_GROUP_DM;
 
-	g_hash_table_replace(components, "id", g_strdup_printf("%" G_GUINT64_FORMAT, channel->id));
-	g_hash_table_replace(components, "name", name);
-	g_hash_table_replace(components, "type", g_memdup(&channel_type, sizeof(channel_type)));
+	g_hash_table_replace(components, g_strdup("id"), g_strdup_printf("%" G_GUINT64_FORMAT, channel->id));
+	g_hash_table_replace(components, g_strdup("name"), name);
+	g_hash_table_replace(components, g_strdup("type"), g_memdup(&channel_type, sizeof(channel_type)));
 
 	PurpleGroup *group = discord_get_or_create_default_group();
 	PurpleChat *chat = purple_chat_new(da->account, name, components);
@@ -2610,8 +2610,8 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 
 		GHashTable *components = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
-		g_hash_table_replace(components, "id", g_strdup_printf("%" G_GUINT64_FORMAT, channel->id));
-		g_hash_table_replace(components, "name", g_strdup(channel->name));
+		g_hash_table_replace(components, g_strdup("id"), g_strdup_printf("%" G_GUINT64_FORMAT, channel->id));
+		g_hash_table_replace(components, g_strdup("name"), g_strdup(channel->name));
 
 		PurpleChat *chat = purple_chat_new(da->account, channel->name, components);
 		purple_blist_add_chat(chat, group, NULL);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3374,30 +3374,35 @@ discord_chat_leave(PurpleConnection *pc, int id)
 	discord_chat_leave_by_room_id(pc, room_id);
 }
 
+/* Invite to a _group DM_
+ * The API for inviting to a guild is different, TODO implement that one too */
+
 static void
 discord_chat_invite(PurpleConnection *pc, int id, const char *message, const char *who)
 {
-	// DiscordAccount *ya;
-	// const gchar *room_id;
-	// PurpleChatConversation *chatconv;
-	// JsonObject *data = json_object_new();
+	DiscordAccount *ya;
+	gchar *room_id;
+	PurpleChatConversation *chatconv;
+	DiscordChannel *channel;
 
-	// ya = purple_connection_get_protocol_data(pc);
-	// chatconv = purple_conversations_find_chat(pc, id);
-	// room_id = purple_conversation_get_data(PURPLE_CONVERSATION(chatconv), "id");
-	// if (room_id == NULL) {
-		// room_id = purple_conversation_get_name(PURPLE_CONVERSATION(chatconv));
-	// }
+	JsonObject *data = json_object_new();
 
-	// json_object_set_string_member(data, "msg", "InviteGroupMember");
-	// json_object_set_string_member(data, "groupId", groupId);
-	// json_object_set_int_member(data, "opId", ya->opid++);
-	// json_object_set_string_member(data, "userId", who);
-	// json_object_set_string_member(data, "memberId", "00000000000FFFFF");
-	// json_object_set_string_member(data, "firstName", "");
-	// json_object_set_string_member(data, "lastName", "");
+	ya = purple_connection_get_protocol_data(pc);
+	chatconv = purple_conversations_find_chat(pc, id);
+	room_id = purple_conversation_get_data(PURPLE_CONVERSATION(chatconv), "id");
+	channel = discord_get_channel_global_int(ya, to_int(room_id));
 
-	// discord_socket_write_json(ya, data);
+	printf("Inviting %s\n", who);
+
+/*	data = json_object_new();
+	json_object_set_string_member(data, "status", status_id);
+	postdata = json_object_to_string(data);
+
+	discord_fetch_url_with_method(ya, "PATCH", "https://" DISCORD_API_SERVER "/api/v6/users/@me/settings", postdata, NULL, NULL);
+
+	g_free(postdata);
+	json_object_unref(data);*/
+
 }
 
 static void
@@ -4843,7 +4848,7 @@ plugin_init(PurplePlugin *plugin)
 	prpl_info->send_typing = discord_send_typing;
 	prpl_info->join_chat = discord_join_chat;
 	prpl_info->get_chat_name = discord_get_chat_name;
-	//	prpl_info->chat_invite = discord_chat_invite;
+	prpl_info->chat_invite = discord_chat_invite;
 	prpl_info->chat_send = discord_chat_send;
 	prpl_info->set_chat_topic = discord_chat_set_topic;
 	prpl_info->get_cb_real_name = discord_get_real_name;
@@ -4946,7 +4951,7 @@ discord_protocol_chat_iface_init(PurpleProtocolChatIface *prpl_info)
 	prpl_info->info_defaults = discord_chat_info_defaults;
 	prpl_info->join = discord_join_chat;
 	prpl_info->get_name = discord_get_chat_name;
-	//	prpl_info->invite = discord_chat_invite;
+	prpl_info->invite = discord_chat_invite;
 	prpl_info->set_topic = discord_chat_set_topic;
 	prpl_info->get_user_real_name = discord_get_real_name;
 }

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -369,6 +369,8 @@ discord_free_channel(gpointer data)
 
 	g_hash_table_unref(channel->permission_user_overrides);
 	g_hash_table_unref(channel->permission_role_overrides);
+	g_list_free_full(channel->recipients, g_free);
+
 	g_free(channel);
 }
 
@@ -1843,7 +1845,7 @@ discord_got_group_dm(DiscordAccount *da, JsonObject *data)
 
 	GHashTable *components = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
-	int channel_type = 3;
+	DiscordChannelType channel_type = CHANNEL_GROUP_DM;
 
 	g_hash_table_replace(components, "id", g_strdup_printf("%" G_GUINT64_FORMAT, channel->id));
 	g_hash_table_replace(components, "name", name);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1820,6 +1820,27 @@ discord_got_nick_change(DiscordAccount *da, DiscordUser *user, DiscordGuild *gui
 	g_free(nick);
 }
 
+static gchar *
+discord_name_group_dm(DiscordAccount *da, DiscordChannel *channel) {
+	/* TODO: Disambiguate with same participants, by topic, username nondiscriminator, cut length... */
+	GString *name = g_string_new(NULL);
+	GList *l;
+
+	for (l = channel->recipients; l != NULL; l = l->next) {
+		guint64 *recipient_ptr = l->data;
+		DiscordUser *recipient = discord_get_user_int(da, *recipient_ptr);
+
+		printf("Recipient: %p\n", recipient);
+		g_string_append(name, discord_create_fullname(recipient));
+
+		if (l->next) {
+			g_string_append(name, g_strdup(", "));
+		}
+	}
+
+	return g_string_free(name, FALSE);
+}
+
 static void
 discord_got_group_dm(DiscordAccount *da, JsonObject *data)
 {
@@ -1841,7 +1862,7 @@ discord_got_group_dm(DiscordAccount *da, JsonObject *data)
 	g_hash_table_replace_int64(da->group_dms, channel->id, channel);
 
 	/* Smush into buddy list */
-	gchar *name = from_int(channel->id);
+	gchar *name = discord_name_group_dm(da, channel);
 
 	GHashTable *components = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -68,8 +68,11 @@ gchar *status_strings[4] = {
 };
 
 typedef enum {
-	CHANNEL_TEXT,
-	CHANNEL_VOICE
+	CHANNEL_GUILD_TEXT = 0,
+	CHANNEL_DM = 1,
+	CHANNEL_VOICE = 2,
+	CHANNEL_GROUP_DM = 3,
+	CHANNEL_GUILD_CATEGORY = 4
 } DiscordChannelType;
 
 typedef struct {
@@ -270,7 +273,7 @@ discord_new_channel(JsonObject *json)
 	channel->name = g_strdup(json_object_get_string_member(json, "name"));
 	channel->topic = g_strdup(json_object_get_string_member(json, "topic"));
 	channel->position = json_object_get_int_member(json, "position");
-	channel->type = json_object_get_int_member(json, "type") ? CHANNEL_VOICE : CHANNEL_TEXT;
+	channel->type = json_object_get_int_member(json, "type");
 	channel->last_message_id = to_int(json_object_get_string_member(json, "last_message_id"));
 
 	channel->permission_user_overrides = g_hash_table_new_full(g_int64_hash, g_int64_equal, NULL, g_free);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3375,6 +3375,32 @@ discord_chat_leave(PurpleConnection *pc, int id)
 }
 
 static void
+discord_chat_invite(PurpleConnection *pc, int id, const char *message, const char *who)
+{
+	// DiscordAccount *ya;
+	// const gchar *room_id;
+	// PurpleChatConversation *chatconv;
+	// JsonObject *data = json_object_new();
+
+	// ya = purple_connection_get_protocol_data(pc);
+	// chatconv = purple_conversations_find_chat(pc, id);
+	// room_id = purple_conversation_get_data(PURPLE_CONVERSATION(chatconv), "id");
+	// if (room_id == NULL) {
+		// room_id = purple_conversation_get_name(PURPLE_CONVERSATION(chatconv));
+	// }
+
+	// json_object_set_string_member(data, "msg", "InviteGroupMember");
+	// json_object_set_string_member(data, "groupId", groupId);
+	// json_object_set_int_member(data, "opId", ya->opid++);
+	// json_object_set_string_member(data, "userId", who);
+	// json_object_set_string_member(data, "memberId", "00000000000FFFFF");
+	// json_object_set_string_member(data, "firstName", "");
+	// json_object_set_string_member(data, "lastName", "");
+
+	// discord_socket_write_json(ya, data);
+}
+
+static void
 discord_chat_nick(PurpleConnection *pc, int id, gchar *new_nick)
 {
 	PurpleChatConversation *chatconv;

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1843,8 +1843,6 @@ discord_name_group_dm(DiscordAccount *da, DiscordChannel *channel) {
 static void
 discord_got_group_dm(DiscordAccount *da, JsonObject *data)
 {
-	printf("Got a group DM with...\n");
-
 	DiscordChannel *channel = discord_new_channel(data);
 	JsonArray *recipients = json_object_get_array_member(data, "recipients");
 
@@ -1854,8 +1852,6 @@ discord_got_group_dm(DiscordAccount *da, JsonObject *data)
 								json_array_get_object_element(recipients, i));
 
 		channel->recipients = g_list_prepend(channel->recipients, g_memdup(&(recipient->id), sizeof(guint64)));
-
-		printf("%d: %s\n", i, recipient->name);
 	}
 
 	g_hash_table_replace_int64(da->group_dms, channel->id, channel);
@@ -4079,8 +4075,6 @@ discord_conversation_send_message(DiscordAccount *da, guint64 room_id, const gch
 	gchar *stripped;
 	gchar * final;
 
-	printf("Low level send message -> %lu: %s\n", room_id, message);
-
 	nonce = g_strdup_printf("%" G_GUINT32_FORMAT, g_random_int());
 	g_hash_table_insert(da->sent_message_ids, nonce, nonce);
 
@@ -4130,12 +4124,9 @@ discord_chat_send(PurpleConnection *pc, gint id,
 
 	da = purple_connection_get_protocol_data(pc);
 	chatconv = purple_conversations_find_chat(pc, id);
-	printf("Chat conv: %p\n", chatconv);
 	guint64 *room_id_ptr = purple_conversation_get_data(PURPLE_CONVERSATION(chatconv), "id");
-	printf("Room_id_ptr: %p\n", room_id_ptr);
 	g_return_val_if_fail(room_id_ptr, -1);
 	guint64 room_id = *room_id_ptr;
-	printf("ID: %lu\n", room_id);
 
 	gchar *d_message = g_strdup(message);
 


### PR DESCRIPTION
* Revive group DM implementation #59 
* Add group DMs to buddy list
* Invite functionality
* Handle join/leave channel events

Issues:

* Channel names are static (need to take into account changing participants, name changes, etc)
* Channel names are subject to collision
* Kicking not supported

(Not ready for merge; currently fixing this issues)