### PR TITLE
Use Discord read_state in lieu of tracking ourselves

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -168,6 +168,7 @@ typedef struct {
 	GHashTable *one_to_ones;		/* A store of known room_id's -> username's */
 	GHashTable *one_to_ones_rev;	/* A store of known usernames's -> room_id's */
 	GHashTable *last_message_id_dm; /* A store of known room_id's -> last_message_id's */
+	GHashTable *read_state;			/* A store of known room_id's -> read_state */
 	GHashTable *sent_message_ids;   /* A store of message id's that we generated from this instance */
 	GHashTable *result_callbacks;   /* Result ID -> Callback function */
 	GQueue *received_message_queue; /* A store of the last 10 received message id's for de-dup */
@@ -1862,7 +1863,7 @@ discord_got_group_dm(DiscordAccount *da, JsonObject *data)
 
 	DiscordChannelType channel_type = CHANNEL_GROUP_DM;
 
-	g_hash_table_replace(components, g_strdup("id"), g_strdup_printf("%" G_GUINT64_FORMAT, channel->id));
+	g_hash_table_replace(components, g_strdup("id"), from_int(channel->id));
 	g_hash_table_replace(components, g_strdup("name"), g_strdup(channel->name));
 	g_hash_table_replace(components, g_strdup("type"), g_memdup(&channel_type, sizeof(channel_type)));
 
@@ -2718,14 +2719,15 @@ discord_got_read_states(DiscordAccount *da, JsonNode *node, gpointer user_data)
 		JsonObject *state = json_array_get_object_element(states, i);
 
 		const gchar *channel = json_object_get_string_member(state, "id");
-		const gchar *last_id = json_object_get_string_member(state, "last_message_id");
+		guint64 channel_id = to_int(channel);
+		guint64 last_id = to_int(json_object_get_string_member(state, "last_message_id"));
 		guint mentions = json_object_get_int_member(state, "mention_count");
 
 		if (mentions) {
 			gboolean isDM = g_hash_table_contains(da->one_to_ones, channel);
 
 			if (isDM) {
-				discord_get_history(da, channel, last_id, mentions * 2);
+				discord_get_history(da, channel, from_int(last_id), mentions * 2);
 			} else {
 				/* TODO: fetch channel history */
 				DiscordChannel *dchannel = discord_get_channel_global(da, channel);
@@ -2734,6 +2736,8 @@ discord_got_read_states(DiscordAccount *da, JsonNode *node, gpointer user_data)
 				}
 			}
 		}
+
+		g_hash_table_replace(da->read_state, g_strdup(channel), g_memdup(&last_id, sizeof(last_id)));
 	}
 }
 
@@ -2838,15 +2842,10 @@ discord_login(PurpleAccount *account)
 	da->pc = pc;
 	da->cookie_table = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
-	da->last_load_last_message_id = purple_account_get_int(account, "last_message_id_high", 0);
-
-	if (da->last_load_last_message_id != 0) {
-		da->last_load_last_message_id = (da->last_load_last_message_id << 32) | ((guint64) purple_account_get_int(account, "last_message_id_low", 0) & 0xFFFFFFFF);
-	}
-
 	da->one_to_ones = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	da->one_to_ones_rev = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	da->last_message_id_dm = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	da->read_state = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	da->sent_message_ids = g_hash_table_new_full(g_str_insensitive_hash, g_str_insensitive_equal, g_free, NULL);
 	da->result_callbacks = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	da->received_message_queue = g_queue_new();
@@ -2909,6 +2908,8 @@ discord_close(PurpleConnection *pc)
 	da->one_to_ones_rev = NULL;
 	g_hash_table_unref(da->last_message_id_dm);
 	da->last_message_id_dm = NULL;
+	g_hash_table_unref(da->read_state);
+	da->read_state = NULL;
 	g_hash_table_unref(da->sent_message_ids);
 	da->sent_message_ids = NULL;
 	g_hash_table_unref(da->result_callbacks);
@@ -3539,8 +3540,6 @@ discord_get_chat_name(GHashTable *data)
 	return g_strdup(temp);
 }
 
-static void discord_set_room_last_id(DiscordAccount *da, guint64 channel_id, guint64 last_id);
-
 static void
 discord_got_history_of_room(DiscordAccount *da, JsonNode *node, gpointer user_data)
 {
@@ -3563,8 +3562,6 @@ discord_got_history_of_room(DiscordAccount *da, JsonNode *node, gpointer user_da
 	}
 
 	if (rolling_last_message_id != 0) {
-		discord_set_room_last_id(da, channel->id, rolling_last_message_id);
-
 		if (rolling_last_message_id < last_message) {
 			/* Request the next 100 messages */
 			gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/v6/channels/%" G_GUINT64_FORMAT "/messages?limit=100&after=%" G_GUINT64_FORMAT, channel->id, rolling_last_message_id);
@@ -3587,66 +3584,6 @@ discord_got_history_static(DiscordAccount *da, JsonNode *node, gpointer user_dat
 
 		discord_process_message(da, message);
 	}
-}
-
-/* libpurple can't store a 64bit int on a 32bit machine, so convert to
- * something more usable instead (puke). also needs to work cross platform, in
- * case the accounts.xml is being shared (double puke)
- */
-
-static guint64
-discord_get_room_last_id(DiscordAccount *da, guint64 id)
-{
-	guint64 last_message_id = da->last_load_last_message_id;
-	PurpleBlistNode *blistnode = NULL;
-	gchar *channel_id = g_strdup_printf("%" G_GUINT64_FORMAT, id);
-
-	if (g_hash_table_contains(da->one_to_ones, channel_id)) {
-		/* is a direct message */
-		blistnode = PURPLE_BLIST_NODE(purple_blist_find_buddy(da->account, g_hash_table_lookup(da->one_to_ones, channel_id)));
-	} else {
-		/* twas a group chat */
-		blistnode = PURPLE_BLIST_NODE(purple_blist_find_chat(da->account, channel_id));
-	}
-
-	if (blistnode != NULL) {
-		guint64 last_room_id = purple_blist_node_get_int(blistnode, "last_message_id_high");
-
-		if (last_room_id != 0) {
-			last_room_id = (last_room_id << 32) | ((guint64) purple_blist_node_get_int(blistnode, "last_message_id_low") & 0xFFFFFFFF);
-
-			last_message_id = MAX(da->last_message_id, last_room_id);
-		}
-	}
-
-	g_free(channel_id);
-	return last_message_id;
-}
-
-static void
-discord_set_room_last_id(DiscordAccount *da, guint64 id, guint64 last_id)
-{
-	PurpleBlistNode *blistnode = NULL;
-	gchar *channel_id = g_strdup_printf("%" G_GUINT64_FORMAT, id);
-
-	if (g_hash_table_contains(da->one_to_ones, channel_id)) {
-		/* is a direct message */
-		blistnode = PURPLE_BLIST_NODE(purple_blist_find_buddy(da->account, g_hash_table_lookup(da->one_to_ones, channel_id)));
-	} else {
-		/* twas a group chat */
-		blistnode = PURPLE_BLIST_NODE(purple_blist_find_chat(da->account, channel_id));
-	}
-
-	if (blistnode != NULL) {
-		purple_blist_node_set_int(blistnode, "last_message_id_high", last_id >> 32);
-		purple_blist_node_set_int(blistnode, "last_message_id_low", last_id & 0xFFFFFFFF);
-	}
-
-	da->last_message_id = MAX(da->last_message_id, last_id);
-	purple_account_set_int(da->account, "last_message_id_high", last_id >> 32);
-	purple_account_set_int(da->account, "last_message_id_low", last_id & 0xFFFFFFFF);
-
-	g_free(channel_id);
 }
 
 /* TODO: Cache better, sane defaults */
@@ -3861,10 +3798,15 @@ discord_join_chat(PurpleConnection *pc, GHashTable *chatdata)
 	}
 
 	/* Get any missing messages */
-	guint64 last_message_id = discord_get_room_last_id(da, id);
+	guint64 *last_message_id = g_hash_table_lookup(da->read_state, g_hash_table_lookup(chatdata, "id"));
 
-	if (last_message_id != 0 && channel->last_message_id > last_message_id) {
-		gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/v6/channels/%" G_GUINT64_FORMAT "/messages?limit=100&after=%" G_GUINT64_FORMAT, id, last_message_id);
+	if(!last_message_id) {
+		/* No history to grab! */
+		return;
+	}
+
+	if (*last_message_id != 0 && channel->last_message_id > *last_message_id) {
+		gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/v6/channels/%" G_GUINT64_FORMAT "/messages?limit=100&after=%" G_GUINT64_FORMAT, id, *last_message_id);
 		discord_fetch_url(da, url, NULL, discord_got_history_of_room, channel);
 		g_free(url);
 	}
@@ -3900,14 +3842,12 @@ discord_mark_room_messages_read(DiscordAccount *da, guint64 channel_id)
 		purple_debug_info("discord", "Won't ack message ID == 0");
 	}
 
-	guint64 known_message_id = discord_get_room_last_id(da, channel_id);
+	guint64 *known_message_id = g_hash_table_lookup(da->read_state, from_int(channel_id));
 
-	if (last_message_id == known_message_id) {
+	if (known_message_id && last_message_id == *known_message_id) {
 		/* Up to date */
 		return;
 	}
-
-	discord_set_room_last_id(da, channel_id, last_message_id);
 
 	gchar *url;
 


### PR DESCRIPTION
If this works (unclear), this makes read state behaviour much more predictable by using Discord's acking mechanism instead of rolling our own