### PR TITLE
Fallback to git when constructing PLUGIN_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,14 @@ DIR_PERM = 0755
 LIB_PERM = 0755
 FILE_PERM = 0644
 
-REVISION_ID = $(shell hg id -i)
-REVISION_NUMBER = $(shell hg id -n)
+# Note: Use "-C .git" to avoid ascending to parent dirs if .git not present
+GIT_REVISION_ID = $(shell git -C .git rev-parse --short HEAD 2>/dev/null)
+REVISION_ID = $(shell hg id -i 2>/dev/null)
+REVISION_NUMBER = $(shell hg id -n 2>/dev/null)
 ifneq ($(REVISION_ID),)
 PLUGIN_VERSION ?= 0.9.$(shell date +%Y.%m.%d).git.r$(REVISION_NUMBER).$(REVISION_ID)
+else ifneq ($(GIT_REVISION_ID),)
+PLUGIN_VERSION ?= 0.9.$(shell date +%Y.%m.%d).git.$(GIT_REVISION_ID)
 else
 PLUGIN_VERSION ?= 0.9.$(shell date +%Y.%m.%d)
 endif


### PR DESCRIPTION
The Makefile attempted to use the output of `hg id` for constructing `PLUGIN_VERSION`.  This fails since the project is not using Mercurial.  Presumably this was copied from another project, because it has been present since the initial commit.

This PR uses the git short commit hash instead.  Since git doesn't provide an equivalent to the Mercurial local revision number, that part is removed.

Note:  Git errors are suppressed since the project may be built on systems without git installed (e.g. distro build systems/chroots) or without the git metadata (e.g. released sources or downloaded
zip/tarball from GitHub).

Thanks for considering,
Kevin

P.S.  You may want to consider using the most recent commit date instead of the current date to make the build reproducible (e.g. `git show -s --format=%cd.%h --date=format:%Y.%m.%d`).  If so, I can update this PR to include that change as well.