### PR TITLE
Only add group to blist when creating a new one

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2818,10 +2818,12 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 
 	if (!group) {
 		group = purple_group_new(guild->name);
-	}
 
-	if (!group) {
-		return;
+		if (!group) {
+			return;
+		}
+
+		purple_blist_add_group(group, NULL);
 	}
 
 	GHashTableIter iter;
@@ -2855,8 +2857,6 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 
 		discord_add_channel_to_blist(da, channel, group);
 	}
-
-	purple_blist_add_group(group, group->node.prev);
 }
 
 static void


### PR DESCRIPTION
Preserves guild group order in a way that's compatible with purple3.

Fixes #163 