### PR TITLE
Display first word of multiline code blocks

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1631,10 +1631,6 @@ discord_convert_markdown(const gchar *html)
 		} else if (c == '`') {
 			if (html[i + 1] == '`' && html[i + 2] == '`') {
 				if (!s_codeblock) {
-					while (html[i] != '\n' && html[i] != ' ' && html[i]) {
-						++i;
-					}
-
 					out = g_string_append(out, "<br/><span style='font-family: monospace; white-space: pre'>");
 				} else {
 					out = g_string_append(out, "</span>");


### PR DESCRIPTION
When receiving a direct message with text on the first line of a multi-line code block, libpurple-based clients do not show the characters up to the first space or newline character.  For example, sending the text from example 2 of [Markdown Text 101](https://support.discordapp.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-):

    ```haikus written here
    really shouldn't cause conflict
    markdown is more fun```

Is displayed in the Discord web client as:

<pre><code>haikus written here
really shouldn't cause conflict
markdown is more fun</code></pre>

and displayed in libpurple-based clients as:

<pre><code>written here
really shouldn't cause conflict
markdown is more fun</code></pre>

Unlike other markdown variants, Discord does not treat the opening word or line of a fenced code block as an [info string](https://spec.commonmark.org/0.28/#info-string).

This PR adjusts the behavior to match the Discord web client (and presumably the other Discord clients, although I have only tested the web client) by displaying the first word after the start of a fenced code block.

Thanks for considering,
Kevin