### PR TITLE
Conditionally add break after multiline code block

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1579,6 +1579,18 @@ discord_underscore_match(const gchar *html, int i)
 	return FALSE;
 }
 
+static gboolean
+discord_has_nonspace_before_newline(const gchar *html, int i)
+{
+	while (html[i] && html[i] != '\n') {
+		if (!g_ascii_isspace(html[i++])) {
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
 static gchar *
 discord_convert_markdown(const gchar *html)
 {
@@ -1634,6 +1646,11 @@ discord_convert_markdown(const gchar *html)
 					out = g_string_append(out, "<br/><span style='font-family: monospace; white-space: pre'>");
 				} else {
 					out = g_string_append(out, "</span>");
+
+					/* Ensure no text on same line after code. */
+					if (discord_has_nonspace_before_newline(html, i + 3)) {
+						out = g_string_append(out, "<br/>");
+					}
 				}
 
 				i += 2;

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1634,9 +1634,9 @@ discord_convert_markdown(const gchar *html)
 					out = g_string_append(out, "<br/><span style='font-family: monospace; white-space: pre'>");
 				} else {
 					out = g_string_append(out, "</span>");
-					i += 2;
 				}
 
+				i += 2;
 				s_codeblock = !s_codeblock;
 			} else {
 				HTML_TOGGLE_OUT(s_codebit, "<span style='font-family: monospace; white-space: pre'>", "</span>");


### PR DESCRIPTION
In the Discord web client (and presumably others) multiline code blocks are rendered using `<pre><code>text</code></pre>`.  Since `<pre>` is a block-level element, the text is always displayed on its own line(s).  Mimic this behavior by adding a line break when text following the block would appear on the same line.  Ignore collapsible white space, as a browser would.

This PR includes a small fix for duplicate markup at the start of multiline code blocks.  I can split that into a separate PR if you'd prefer.

Thanks,
Kevin

Fixes: #207