### PR TITLE
Fetch own avatar

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -4693,10 +4693,8 @@ discord_get_avatar(DiscordAccount *da, DiscordUser *user, gboolean is_buddy)
 		gchar *username = discord_create_fullname(user);
 		checksum = purple_buddy_icons_get_checksum_for_user(purple_blist_find_buddy(da->account, username));
 		g_free(username);
-
 	} else if (user->id == da->self_user_id) {
 		checksum = purple_account_get_string(da->account, "avatar_checksum", "");
-		printf("Fetching self..\n");
 	} else {
 		/* XXX: This should never happen unless you started writing
 		 * code for fetching avatars in guilds */
@@ -4707,7 +4705,6 @@ discord_get_avatar(DiscordAccount *da, DiscordUser *user, gboolean is_buddy)
 	if (purple_strequal(checksum, user->avatar)) {
 		return;
 	}
-	printf("Cache miss\n");
 
 	GString *url = g_string_new("https://cdn.discordapp.com/avatars/");
 	g_string_append_printf(url, "%" G_GUINT64_FORMAT, user->id);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1268,7 +1268,7 @@ static void discord_got_history_of_room(DiscordAccount *da, JsonNode *node, gpoi
 static void discord_populate_guild(DiscordAccount *da, JsonObject *guild);
 static void discord_got_guilds(DiscordAccount *da, JsonNode *node, gpointer user_data);
 static void discord_got_avatar(DiscordAccount *da, JsonNode *node, gpointer user_data);
-static void discord_get_avatar(DiscordAccount *da, DiscordUser *user);
+static void discord_get_avatar(DiscordAccount *da, DiscordUser *user, gboolean is_buddy);
 static void discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild);
 
 static const gchar *discord_normalise_room_name(const gchar *guild_name, const gchar *name);
@@ -2335,6 +2335,10 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 		discord_got_guilds(da, json_object_get_member(data, "guilds"), NULL);
 		discord_got_read_states(da, json_object_get_member(data, "read_state"), NULL);
 
+		/* Fetch our own avatar */
+		self_user_obj = discord_get_user(da, da->self_user_id);
+		discord_get_avatar(da, self_user_obj, FALSE);
+
 		if (!self_user_obj) {
 			/* ...But remove afterward, this user object is partial */
 			g_hash_table_remove(da->new_users, &da->self_user_id);
@@ -2783,7 +2787,7 @@ discord_create_relationship(DiscordAccount *da, JsonObject *json)
 			purple_blist_add_buddy(buddy, NULL, discord_get_or_create_default_group(), NULL);
 		}
 
-		discord_get_avatar(da, user);
+		discord_get_avatar(da, user, TRUE);
 		
 	} else if (type == 2) {
 		/* blocked buddy */
@@ -4647,7 +4651,7 @@ discord_chat_set_topic(PurpleConnection *pc, int id, const char *topic)
 }
 
 static void
-discord_got_avatar(DiscordAccount *ya, JsonNode *node, gpointer user_data)
+discord_got_avatar(DiscordAccount *da, JsonNode *node, gpointer user_data)
 {
 	DiscordUser *user = user_data;
 	gchar *username = discord_create_fullname(user);
@@ -4662,25 +4666,34 @@ discord_got_avatar(DiscordAccount *ya, JsonNode *node, gpointer user_data)
 		response_len = json_object_get_int_member(response, "len");
 		response_dup = g_memdup(response_str, response_len);
 
-		purple_buddy_icons_set_for_user(ya->account, username, response_dup, response_len, user->avatar);
+		if (user->id == da->self_user_id) {
+			purple_buddy_icons_set_account_icon(da->account, response_dup, response_len);
+		} else {
+			purple_buddy_icons_set_for_user(da->account, username, response_dup, response_len, user->avatar);
+		}
 	}
 	
 	g_free(username);
 }
 
 static void
-discord_get_avatar(DiscordAccount *da, DiscordUser *user)
+discord_get_avatar(DiscordAccount *da, DiscordUser *user, gboolean is_buddy)
 {
 	if (!user) {
 		return;
 	}
 
-	gchar *username = discord_create_fullname(user);
-	const gchar *checksum = purple_buddy_icons_get_checksum_for_user(purple_blist_find_buddy(da->account, username));
-	g_free(username);
+	/* We can only verify checksums for buddies due to libpurple
+	 * limitations */
 
-	if (purple_strequal(checksum, user->avatar)) {
-		return;
+	if (is_buddy) {
+		gchar *username = discord_create_fullname(user);
+		const gchar *checksum = purple_buddy_icons_get_checksum_for_user(purple_blist_find_buddy(da->account, username));
+		g_free(username);
+
+		if (purple_strequal(checksum, user->avatar)) {
+			return;
+		}
 	}
 
 	GString *url = g_string_new("https://cdn.discordapp.com/avatars/");


### PR DESCRIPTION
Both Discord and libpurple maintain the concept of account icons, like buddy icons but for the account holder herself. Unfortunately, these do not get much use in prpls (even libpurple native prpls), because they are scarcely used in the Pidgin UI. The Discord UI, by contrast, uses "avatars" everywhere, so it makes sense to have this available.

This patch modifies get_avatar/got_avatar to support self-avatars, as well as hooks in this function at READY.

It further manages checksums itself via purple_account settings, as checksumming is normally only available for buddy icons.

It can be confirmed working by navigating to the account settings pane in Pidgin, as well as playing a much more active role in mythical avatar-heavy libpurple-based clients.