### PR TITLE
Pinned message support (read-only), closes #93

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2096,7 +2096,19 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 
 		g_free(username);
 	} else if (purple_strequal(type, "MESSAGE_CREATE") || purple_strequal(type, "MESSAGE_UPDATE")) { /* TODO */
-		discord_process_message(da, data, purple_strequal(type, "MESSAGE_UPDATE") ? DISCORD_MESSAGE_EDITED : DISCORD_MESSAGE_PINNED);
+		unsigned msgtype = DISCORD_MESSAGE_NORMAL;
+
+		if (purple_strequal(type, "MESSAGE_UPDATE")) {
+			/* An update could mean that we were edited or that we
+			 * were pinned. If it's both, default to just showing
+			 * pinned. */
+
+			gboolean is_pinned = json_object_get_boolean_member(data, "pinned");
+
+			msgtype = is_pinned ? DISCORD_MESSAGE_PINNED : DISCORD_MESSAGE_EDITED;
+		}
+
+		discord_process_message(da, data, msgtype);
 
 		const gchar *channel_id = json_object_get_string_member(data, "channel_id");
 

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3671,9 +3671,18 @@ discord_got_pinned(DiscordAccount *da, JsonNode *node, gpointer user_data)
 
 	JsonArray *messages = json_node_get_array(node);
 
-	for (int i = 0; i < json_array_get_length(messages); ++i) {
-		JsonObject *message = json_array_get_object_element(messages, i);
-		discord_process_message(da, message, DISCORD_MESSAGE_PINNED);
+	int count = json_array_get_length(messages);
+
+	if (count) {
+		/* Display each message with a pinned icon through the normal channel */
+
+		for (int i = 0; i < count; ++i) {
+			JsonObject *message = json_array_get_object_element(messages, i);
+			discord_process_message(da, message, DISCORD_MESSAGE_PINNED);
+		}
+	} else {
+		/* Don't make the user think we forget about them */
+		purple_conversation_write(conv, NULL, _("No pinned messages"), PURPLE_MESSAGE_SYSTEM, time(NULL));
 	}
 }
 


### PR DESCRIPTION
Adds a /pinned command to read pinned messages. Displays messages on-pin, rather than confusingly looking like the newly-pinned message was edited.

This PR does not add support for pinning messages ourselves; this is blocked on the usual libpurple gaps also affecting edits, etc.