### PR TITLE
Strip timestamps when building PNG files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,13 +130,13 @@ install: $(DISCORD_TARGET) install-icons install-locales
 	install -m $(LIB_PERM) -p $(DISCORD_TARGET) $(DISCORD_DEST)
 
 discord16.png: discord-alt-logo.svg
-	convert -background none discord-alt-logo.svg -resize 16x16 discord16.png
+	convert -strip -background none discord-alt-logo.svg -resize 16x16 discord16.png
 
 discord22.png: discord-alt-logo.svg
-	convert -background none discord-alt-logo.svg -resize 22x22 discord22.png
+	convert -strip -background none discord-alt-logo.svg -resize 22x22 discord22.png
 
 discord48.png: discord-alt-logo.svg
-	convert -background none discord-alt-logo.svg -resize 48x48 discord48.png
+	convert -strip -background none discord-alt-logo.svg -resize 48x48 discord48.png
 
 install-icons: discord16.png discord22.png discord48.png
 	mkdir -m $(DIR_PERM) -p $(DISCORD_ICONS_DEST)/16


### PR DESCRIPTION
Otherwise the build process will not be deterministic.

See-also: https://reproducible-builds.org/
See-also: https://wiki.debian.org/ReproducibleBuilds/TimestampsInPNG