### PR TITLE
Fix off-by-one on history retrieval

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -4138,11 +4138,11 @@ discord_got_history_of_room(DiscordAccount *da, JsonNode *node, gpointer user_da
 		JsonObject *message = json_array_get_object_element(messages, i);
 		guint64 id = to_int(json_object_get_string_member(message, "id"));
 
+		rolling_last_message_id = discord_process_message(da, message, DISCORD_MESSAGE_NORMAL);
+
 		if (id >= last_message) {
 			break;
 		}
-
-		rolling_last_message_id = discord_process_message(da, message, DISCORD_MESSAGE_NORMAL);
 	}
 
 	if (rolling_last_message_id != 0) {


### PR DESCRIPTION
Original code for discord_got_history_of_room breaks before the last message has been processed. This reverses the order of the discord_process_message call and the break and should fix #159 . Note that I'm not particularly familiar with the code so I don't necessarily know all the implications of this change, but it does seem to work in my personal testing.