### PR TITLE
gettext added to dependencies in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Thank you to Penaz for this package.
 
 Compiling
 ---------
-Requires devel headers/libs for libpurple and libjson-glib [libglib2.0-dev, libjson-glib-dev and libpurple-dev], as well as ImageMagick [imagemagick].
+Requires devel headers/libs for libpurple and libjson-glib [libglib2.0-dev, libjson-glib-dev and libpurple-dev], as well as ImageMagick [imagemagick] and [gettext].
 ```bash
 	git clone git://github.com/EionRobb/purple-discord.git
 	cd purple-discord


### PR DESCRIPTION
Otherwise it throws an error upon compilation when under a Debian based OS.

I can't contribute in any way to the project outside testing builds on my Pi 3B+ running Raspbian 9 armhf, if necessary, but I did notice this dependency was missing from the list which isn't included in stock Debian/Raspbian so worth adding it for obvious reasons :stuck_out_tongue: : 

Thanks for the hard work you put into this project, it's very useful to see a proper FOSS library for discord and also really helps us using discord on lower end hardware so it's absolutely appreciated <3