### PR TITLE
Respect notifications settings from web client

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1766,6 +1766,16 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 	DiscordGuild *guild = NULL;
 	DiscordChannel *channel = discord_get_channel_global_int_guild(da, channel_id, &guild);
 
+	/* Check if we should receive messages at all and shortcircuit if not,
+	 * unless the user already opened the channel */
+
+	gboolean muted = channel ? channel->muted : FALSE;
+
+	if (muted) {
+		if (purple_conversations_find_chat(da->pc, discord_chat_hash(channel_id)) == NULL)
+			return msg_id;
+	}
+
 	if (author_id == da->self_user_id) {
 		flags = PURPLE_MESSAGE_SEND | PURPLE_MESSAGE_REMOTE_SEND | PURPLE_MESSAGE_DELAYED;
 	} else {

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2208,6 +2208,19 @@ discord_name_group_dm(DiscordAccount *da, DiscordChannel *channel) {
 	return g_string_free(name, FALSE);
 }
 
+DiscordChannel *
+discord_channel_from_chat(DiscordAccount *da, PurpleChat *chat)
+{
+	/* Grab the ID */
+	GHashTable *components = purple_chat_get_components(chat);
+	const gchar *chat_id = g_hash_table_lookup(components, "id");
+
+	if (!chat_id)
+		return NULL;
+
+	/* Lookup the channel */
+	return discord_get_channel_global(da, chat_id);
+}
 
 PurpleChat *
 discord_find_chat_from_node(PurpleAccount *account, const char *id, PurpleBlistNode *root)

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -97,6 +97,13 @@ typedef enum {
 	CHANNEL_GUILD_CATEGORY = 4
 } DiscordChannelType;
 
+typedef enum {
+	NOTIFICATIONS_ALL = 0,
+	NOTIFICATIONS_MENTIONS = 1,
+	NOTIFICATIONS_NONE = 2,
+	NOTIFICATIONS_INHERIT = 3,
+} DiscordNotificationLevel;
+
 typedef struct {
 	guint64 id;
 	gchar *name;
@@ -122,6 +129,9 @@ typedef struct {
 	GHashTable *permission_user_overrides;
 	GHashTable *permission_role_overrides;
 	GList *recipients; /* For group DMs */
+	gboolean suppress_everyone;
+	gboolean muted;
+	DiscordNotificationLevel notification_level;
 } DiscordChannel;
 
 typedef struct {

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1782,7 +1782,13 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 		flags = PURPLE_MESSAGE_RECV;
 	}
 
-	if (mentions) {
+	/* Check for mentions, but only if the user has not globally disabled
+	 * mentions for the channel. If the level is ALL or MENTIONS, it's
+	 * okay; we just check for NONE */
+
+	gboolean mentionable = channel ? (channel->notification_level != NOTIFICATIONS_NONE) : FALSE;
+
+	if (mentions && mentionable) {
 		for (i = json_array_get_length(mentions) - 1; i >= 0; i--) {
 			JsonObject *user = json_array_get_object_element(mentions, i);
 			guint64 id = to_int(json_object_get_string_member(user, "id"));
@@ -1793,7 +1799,7 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 		}
 	}
 
-	if (mention_roles && guild) {
+	if (mention_roles && guild && mentionable) {
 		DiscordUser *self = discord_get_user(da, da->self_user_id);
 		if (self) {
 			DiscordGuildMembership *membership = g_hash_table_lookup_int64(self->guild_memberships, guild->id);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1809,7 +1809,12 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 		escaped_content = discord_replace_mentions_bare(da, guild, escaped_content);
 	}
 
-	if (json_object_get_boolean_member(data, "mention_everyone")) {
+	/* Ping for @everyone, but only if we didn't suppress it in the channel */
+
+	gboolean mention_everyone = json_object_get_boolean_member(data, "mention_everyone");
+	gboolean everyone_suppressed = channel ? channel->suppress_everyone : FALSE;
+
+	if (mention_everyone && !everyone_suppressed) {
 		flags |= PURPLE_MESSAGE_NICK;
 	}
 	

--- a/po/es.po
+++ b/po/es.po
@@ -5,8 +5,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.9\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-16 11:00-0800\n"
-"PO-Revision-Date: 2018-12-16 12:23-0700\n"
+"POT-Creation-Date: 2019-08-25 17:42-0700\n"
+"PO-Revision-Date: 2019-08-25 12:23-0700\n"
 "Last-Translator: Alyssa Rosenzweig <alyssa@rosenzweig.io>\n"
 "Language-Team: es <LL@li.org>\n"
 "Language: es\n"
@@ -26,32 +26,11 @@ msgstr "EDITADO: %s"
 msgid "Group DMs"
 msgstr "MDs de grupo"
 
-msgid "Text"
-msgstr "Texto"
-
-msgid "Direct Message"
-msgstr "Mensaje Directo"
-
-msgid "Voice"
-msgstr "Voz"
-
-msgid "Group DM"
-msgstr "MD de grupo"
-
-msgid "Guild Category"
-msgstr "Categoria de servidor"
-
-msgid "Unknown"
-msgstr "Desconocido"
-
 msgid "ID"
 msgstr "Identificación"
 
-msgid "Name"
-msgstr "Nombre"
-
-msgid "Room Type"
-msgstr "Tipo de sala"
+msgid "Topic"
+msgstr "Sujeto"
 
 msgid "Cancelled 2FA auth"
 msgstr "Autenticación de dos factores cancelada"
@@ -75,6 +54,9 @@ msgstr "_Iniciar sesión"
 msgid "_Cancel"
 msgstr "_Cancelar"
 
+msgid "Need CAPTCHA to login. Consider using Harmony first, then retry."
+msgstr "CAPTCHA necesitado para autenticar. Intente con Harmony primero, y intente de nuevo después."
+
 msgid "Bad username/password"
 msgstr "Nombre de usuario o contraseña incorrecto"
 
@@ -96,6 +78,9 @@ msgstr "No se puede conectar al gateway"
 msgid "No pinned messages"
 msgstr "Ningún mensaje anclado"
 
+msgid "Name"
+msgstr "Nombre"
+
 msgid "Bad channel type"
 msgstr "Mal tipo de canal"
 
@@ -112,7 +97,8 @@ msgid "Invalid channel for this user"
 msgstr "Canal inválido para este usuario"
 
 msgid "Cannot send a message to someone who is not on your friend list."
-msgstr "No se puede enviar un mensaje a alguien que no está en su lista de amigos"
+msgstr ""
+"No se puede enviar un mensaje a alguien que no está en su lista de amigos"
 
 #, c-format
 msgid "No users with tag %s exist"
@@ -152,6 +138,12 @@ msgstr "Servidores mutuales"
 msgid "Invisible"
 msgstr "Invisible"
 
+msgid "Unmute"
+msgstr "Desenmudecer"
+
+msgid "Mute"
+msgstr "Enmudecer"
+
 #, c-format
 msgid "Playing %s"
 msgstr "Jugando %s"
@@ -167,6 +159,15 @@ msgstr "Automáticamente crear salas en la lista de amigos"
 
 msgid "Number of users in a large channel"
 msgstr "Número de usuarios en un gran canal"
+
+msgid "Display custom emoji as inline images"
+msgstr "Mostrar emoji personalizado como imagenes en línea"
+
+msgid "Open chat when you are @mention'd"
+msgstr "Abrir conversación cuando le @mencionó"
+
+msgid "Auth token"
+msgstr "Código de autenticación"
 
 msgid "Join a server"
 msgstr "Entrar a un servidor"
@@ -212,6 +213,27 @@ msgstr "Plug-in del Protocolo de Discord."
 
 msgid "Adds Discord protocol support to libpurple."
 msgstr "Añadir el protocolo de Discord a libpurple."
+
+#~ msgid "Text"
+#~ msgstr "Texto"
+
+#~ msgid "Direct Message"
+#~ msgstr "Mensaje Directo"
+
+#~ msgid "Voice"
+#~ msgstr "Voz"
+
+#~ msgid "Group DM"
+#~ msgstr "MD de grupo"
+
+#~ msgid "Guild Category"
+#~ msgstr "Categoria de servidor"
+
+#~ msgid "Unknown"
+#~ msgstr "Desconocido"
+
+#~ msgid "Room Type"
+#~ msgstr "Tipo de sala"
 
 #~ msgid "In-Game"
 #~ msgstr "En juego"


### PR DESCRIPTION
Closes #156

This MR parses the notifications settings sent in the READY packet (they are undocumented officially; see https://github.com/discordjs/discord.js/pull/1365/files for reference).

It then uses the settings to modify message receive behaviour, allowing channels to be muted, mentions to be suppressed, and @everyone mentions to be suppressed.

The next step will be to allow setting these levels from the libpurple client itself; I'm not sure how best to expose this functionality. After that, I'd like us to think about dropping the large-channel hack, but we'll see where this goes.

This MR needs much more extensive testing, but it compiles and I'm about to go to lunch.