### PR TITLE
Fix wrong sign in retrieve-history logic

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -4913,7 +4913,7 @@ discord_got_history_of_room(DiscordAccount *da, JsonNode *node, gpointer user_da
 		JsonObject *message = json_array_get_object_element(messages, i);
 		guint64 id = to_int(json_object_get_string_member(message, "id"));
 
-		if (id > last_message) {
+		if (id < last_message) {
 			rolling_last_message_id = discord_process_message(da, message, DISCORD_MESSAGE_NORMAL);
 		}
 	}


### PR DESCRIPTION
Fixes an error from commit 08ea265 where > was used in place of <.

Previously, history retrieval was broken for me with purple2 on Ubuntu18.04. With this change history fetching now works for me locally.