### PR TITLE
Set the example make parallelism higher in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Requires devel headers/libs for libpurple and libjson-glib [libglib2.0-dev, libj
 ```bash
 	git clone git://github.com/EionRobb/purple-discord.git
 	cd purple-discord
-	make
+	make -j4
 	sudo make install
 ```
 


### PR DESCRIPTION
Updated the README.md so that it has better defaults, it's 2020 and people don't have only one core CPUs any more.