### PR TITLE
Fix potential memory leak on old pidgin versions

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -5842,6 +5842,9 @@ discord_send_im(PurpleConnection *pc,
 
 			discord_fetch_url(da, "https://" DISCORD_API_SERVER "/api/" DISCORD_API_VERSION "/users/@me/channels", postdata, discord_created_direct_message_send, msg);
 
+#if !PURPLE_VERSION_CHECK(3, 0, 0)
+			purple_message_destroy(msg);
+#endif
 			g_free(postdata);
 			json_object_unref(data);
 


### PR DESCRIPTION
Suggested-by: scan-build

libdiscord.c:5805:4: warning: Potential leak of memory pointed to by 'msg'
                        g_free(postdata);
                        ^~~~~~~~~~~~~~~~