### PR TITLE
Fixes double free when DMing

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -5861,9 +5861,6 @@ discord_send_im(PurpleConnection *pc,
 
 			discord_fetch_url(da, "https://" DISCORD_API_SERVER "/api/" DISCORD_API_VERSION "/users/@me/channels", postdata, discord_created_direct_message_send, msg);
 
-#if !PURPLE_VERSION_CHECK(3, 0, 0)
-			purple_message_destroy(msg);
-#endif
 			g_free(postdata);
 			json_object_unref(data);
 


### PR DESCRIPTION
purple 2, msg is set, then freed on line 5864, then freed again in discord_created_direct_message_send on the callback, in my case line 5809. which fails/seg faults. tested on my debian/stretch.