### PR TITLE
Reply/react support proof-of-concept

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -74,8 +74,6 @@
 #define DISCORD_CDN_SERVER "cdn.discordapp.com"
 
 #define DISCORD_EPOCH_MS	1420070400000
-#define DISCORD_EPOCH_S	1420070400
-#define DSCMSGSIZE  (sizeof("dscmsg:") - 1)
 
 #define DISCORD_MESSAGE_NORMAL (0)
 #define DISCORD_MESSAGE_EDITED (1)
@@ -331,6 +329,7 @@ typedef struct _DiscordImgMsgContext {
 	gchar* url;
 	PurpleMessageFlags flags;
 	time_t timestamp;
+	guint64 msg_id;
 } DiscordImgMsgContext;
 
 typedef struct {
@@ -338,6 +337,17 @@ typedef struct {
 	gchar *reactor;
 	gchar *reaction;
 } DiscordReaction;
+
+typedef struct {
+	guint64 room_id;
+	gchar *msg_txt;
+	PurpleConversation *conv;
+} DiscordReply;
+
+typedef struct {
+	guint64 msg_id;
+	time_t when;
+} DiscordMsgTimestamp;
 
 static guint64
 to_int(const gchar *id)
@@ -2003,9 +2013,29 @@ discord_get_react_text(PurpleConversation *conv, JsonArray *reactions, const gch
 }
 
 static void
+discord_save_message_timestamp(PurpleConversation *conv, time_t timestamp, guint64 msg_id)
+{
+	if (conv == NULL) {
+		return;
+	}
+
+	DiscordMsgTimestamp *msg_timestamp = g_new0(DiscordMsgTimestamp, 1);
+	msg_timestamp->when = timestamp;
+	msg_timestamp->msg_id = msg_id;
+	GList *msg_list = purple_conversation_get_data(conv, "msg_timestamp_map");
+	if (msg_list) {
+		msg_list = g_list_append(msg_list, msg_timestamp);
+	} else {
+		msg_list = g_list_append(msg_list, msg_timestamp);
+		purple_conversation_set_data(conv, "msg_timestamp_map", msg_list);
+	}
+}
+
+static void
 discord_download_image_cb(DiscordAccount *da, JsonNode *node, gpointer user_data) {
 	//The returned size can be changed by appending a querystring of ?size=desired_size to the URL. Image size can be any power of two between 16 and 4096.
 	DiscordImgMsgContext *img_context = user_data;
+	PurpleConversation *conv;
 
 	if (node != NULL) {
 		gchar *attachment_show;
@@ -2023,8 +2053,18 @@ discord_download_image_cb(DiscordAccount *da, JsonNode *node, gpointer user_data
 
 		if (img_context->conv_id >= 0) {
 			purple_serv_got_chat_in(da->pc, img_context->conv_id, img_context->from, img_context->flags, attachment_show, img_context->timestamp);
+
+			PurpleChatConversation *chatconv = purple_conversations_find_chat(da->pc, discord_chat_hash(img_context->conv_id));
+			conv = PURPLE_CONVERSATION(chatconv);
+			discord_save_message_timestamp(conv, img_context->timestamp, img_context->msg_id);
+
 		} else {
 			purple_serv_got_im(da->pc, img_context->from, attachment_show, img_context->flags, img_context->timestamp);
+
+			PurpleConvIm *imconv = purple_conversations_find_im_with_account(img_context->from, da->account);
+			conv = PURPLE_CONVERSATION(imconv);
+			discord_save_message_timestamp(conv, img_context->timestamp, img_context->msg_id);
+
 		}
 		g_free(attachment_show);
 
@@ -2032,8 +2072,16 @@ discord_download_image_cb(DiscordAccount *da, JsonNode *node, gpointer user_data
 		purple_debug_error("discord", "Image response node is null!\n");
 		if (img_context->conv_id >= 0) {
 			purple_serv_got_chat_in(da->pc, img_context->conv_id, img_context->from, img_context->flags, img_context->url, img_context->timestamp);
+
+			PurpleChatConversation *chatconv = purple_conversations_find_chat(da->pc, discord_chat_hash(img_context->conv_id));
+			conv = PURPLE_CONVERSATION(chatconv);
+			discord_save_message_timestamp(conv, img_context->timestamp, img_context->msg_id);
 		} else {
 			purple_serv_got_im(da->pc, img_context->from, img_context->url, img_context->flags, img_context->timestamp);
+
+			PurpleConvIm *imconv = purple_conversations_find_im_with_account(img_context->from, da->account);
+			conv = PURPLE_CONVERSATION(imconv);
+			discord_save_message_timestamp(conv, img_context->timestamp, img_context->msg_id);
 		}
 	}
 
@@ -2400,6 +2448,7 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 					msg = purple_message_new_outgoing(username, escaped_content, flags);
 					purple_message_set_time(msg, timestamp);
 					purple_conversation_write_message(conv, msg);
+					discord_save_message_timestamp(conv, timestamp, msg_id);
 					purple_message_destroy(msg);
 				}
 
@@ -2411,6 +2460,9 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 						msg = purple_message_new_outgoing(username, url, flags);
 						purple_message_set_time(msg, timestamp);
 						purple_conversation_write_message(conv, msg);
+						if (!escaped_content || !*escaped_content) {
+							discord_save_message_timestamp(conv, timestamp, msg_id);
+						}
 						purple_message_destroy(msg);
 					}
 				}
@@ -2490,6 +2542,7 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 						img_context->url = g_strdup(url);
 						img_context->flags = flags | PURPLE_MESSAGE_IMAGES;
 						img_context->timestamp = timestamp;
+						img_context->msg_id = msg_id;
 
 						if (conv == NULL) {
 							PurpleIMConversation *imconv;
@@ -2512,6 +2565,7 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 
 					} else {
 						purple_serv_got_im(da->pc, merged_username, url, flags, timestamp);
+						discord_save_message_timestamp(conv, timestamp, msg_id);
 					}
 
 				}
@@ -2597,6 +2651,12 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 
 		if (escaped_content && *escaped_content && msg_type != MESSAGE_GUILD_MEMBER_JOIN && msg_type != MESSAGE_CALL) {
 			purple_serv_got_chat_in(da->pc, discord_chat_hash(channel_id), name, flags, escaped_content, timestamp);
+			if (conv == NULL) {
+				PurpleChatConversation *chatconv = purple_conversations_find_chat(da->pc, discord_chat_hash(channel_id));
+				conv = PURPLE_CONVERSATION(chatconv);
+			}
+
+			discord_save_message_timestamp(conv, timestamp, msg_id);
 		} else if (msg_type == MESSAGE_GUILD_MEMBER_JOIN) {
 			gchar *join_txt = g_strdup_printf(_("%s joined the guild!"), name);
 			if (conv != NULL)
@@ -2629,6 +2689,7 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 					img_context->url = g_strdup(url);
 					img_context->flags = flags | PURPLE_MESSAGE_IMAGES;
 					img_context->timestamp = timestamp;
+					img_context->msg_id = msg_id;
 
 					if (conv == NULL) {
 						PurpleChatConversation *chatconv = purple_conversations_find_chat(da->pc, discord_chat_hash(channel_id));
@@ -2646,13 +2707,18 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 							}
 						} else {
 							purple_serv_got_chat_in(da->pc, discord_chat_hash(channel_id), name, flags, url_log, timestamp);
+							discord_save_message_timestamp(conv, timestamp, msg_id);
 						}
 					} else {
 						purple_serv_got_chat_in(da->pc, discord_chat_hash(channel_id), name, flags, url_log, timestamp);
+						PurpleChatConversation *chatconv = purple_conversations_find_chat(da->pc, discord_chat_hash(channel_id));
+						conv = PURPLE_CONVERSATION(chatconv);
+						discord_save_message_timestamp(conv, timestamp, msg_id);
 					}
 
 				} else {
 					purple_serv_got_chat_in(da->pc, discord_chat_hash(channel_id), name, flags, url_log, timestamp);
+					discord_save_message_timestamp(conv, timestamp, msg_id);
 				}
 
 			}
@@ -2685,6 +2751,14 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 		}
 
 		g_free(name);
+	} else {
+		// Your sent msgs in chats
+		if (conv == NULL) {
+			PurpleChatConversation *chatconv = purple_conversations_find_chat(da->pc, discord_chat_hash(channel_id));
+			conv = PURPLE_CONVERSATION(chatconv);
+		}
+
+		discord_save_message_timestamp(conv, timestamp, msg_id);
 	}
 
 	g_free(escaped_content);
@@ -5587,15 +5661,6 @@ discord_react_cb(DiscordAccount *da, JsonNode *node, gpointer user_data)
 	discord_free_reaction(react);
 }
 
-gint discord_msg_time_comp(gpointer pmsg, gpointer ptime)
-{
-	time_t given_time = *(time_t*)ptime;
-	PurpleConvMessage *msg = (PurpleConvMessage*)pmsg;
-	time_t msg_time = msg->when;
-
-	return !(msg_time == given_time);
-}
-
 static time_t
 discord_parse_timestamp(const gchar *timestring)
 {
@@ -5615,7 +5680,7 @@ discord_parse_timestamp(const gchar *timestring)
 	}
 
 	GDateTime *msg_time = g_date_time_new_from_iso8601(verified_timestring, local_time);
-	printf("%s \n", g_date_time_format_iso8601(msg_time));
+
 
 	g_free(verified_timestring);
 
@@ -6443,6 +6508,7 @@ discord_open_chat(DiscordAccount *da, guint64 id, gboolean present)
 	g_free(id_str);
 
 	purple_conversation_set_data(PURPLE_CONVERSATION(chatconv), "id", g_memdup2(&(id), sizeof(guint64)));
+	purple_conversation_set_data(PURPLE_CONVERSATION(chatconv), "msg_timestamp_map", (GList*)NULL);
 
 	purple_conversation_present(PURPLE_CONVERSATION(chatconv));
 
@@ -7651,12 +7717,6 @@ discord_actions(
 	return m;
 }
 
-typedef struct {
-	guint64 room_id;
-	gchar *msg_txt;
-	PurpleConversation *conv;
-} DiscordReply;
-
 static void
 discord_reply_cb(DiscordAccount *da, JsonNode *node, gpointer user_data)
 {
@@ -7729,17 +7789,22 @@ discord_get_message_id_from_timestamp(PurpleConversation *conv, const gchar *tim
 		return NULL;
 	}
 
-  GList *msg_list = conv->message_history;
-  GList *msg_elem = g_list_find_custom(msg_list, &msg_time, (GCompareFunc)discord_msg_time_comp);
-  PurpleConvMessage *msg = msg_elem->data;
+  GList *msg_list = purple_conversation_get_data(conv, "msg_timestamp_map");
+	GList *msg_elem;
+	purple_debug_info("discord", "Msg_list: ");
+		for (msg_elem = msg_list; msg_elem != NULL; msg_elem = msg_elem->next) {
+			DiscordMsgTimestamp *t = msg_elem->data;
+			if (t->when == msg_time) {
+				break;
+			}
+		}
 
-  if (msg == NULL) {
-    return NULL;
-  }
-
-	const gchar *text = g_strrstr(msg->what, "dscmsg:");
-	g_return_val_if_fail(text && strlen(text) > DSCMSGSIZE, FALSE);
-	return g_strndup((char*)text + DSCMSGSIZE, 18);
+	if (msg_elem) {
+		DiscordMsgTimestamp *msg_timestamp = msg_elem->data;
+		return from_int(msg_timestamp->msg_id);
+	}
+	purple_debug_info("discord", "Can't find message at %ld\n", msg_time);
+	return NULL;
 }
 
 static gboolean

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #ifdef __GNUC__
 #include <unistd.h>
 #endif
@@ -71,6 +72,10 @@
 #define DISCORD_GATEWAY_SERVER_PATH "/?encoding=json&v=9"
 #define DISCORD_API_VERSION "v9"
 #define DISCORD_CDN_SERVER "cdn.discordapp.com"
+
+#define DISCORD_EPOCH_MS	1420070400000
+#define DISCORD_EPOCH_S	1420070400
+#define DSCMSGSIZE  (sizeof("dscmsg:") - 1)
 
 #define DISCORD_MESSAGE_NORMAL (0)
 #define DISCORD_MESSAGE_EDITED (1)
@@ -5582,6 +5587,59 @@ discord_react_cb(DiscordAccount *da, JsonNode *node, gpointer user_data)
 	discord_free_reaction(react);
 }
 
+gint discord_msg_time_comp(gpointer pmsg, gpointer ptime)
+{
+	time_t given_time = *(time_t*)ptime;
+	PurpleConvMessage *msg = (PurpleConvMessage*)pmsg;
+	time_t msg_time = msg->when;
+
+	return !(msg_time == given_time);
+}
+
+static time_t
+discord_parse_timestamp(const gchar *timestring)
+{
+	time_t timestamp;
+	gchar *verified_timestring;
+	GTimeZone *local_time = g_time_zone_new_local();
+	GDateTime *now = g_date_time_new_now_local();
+	gint year = 1970, month = 1, day = 1;
+
+	if (!strchr(timestring, ' ') && !strchr(timestring, 't') && !strchr(timestring, 'T')) {
+		// no separator, so no date attached
+		g_date_time_get_ymd(now, &year, &month, &day);
+
+		verified_timestring = g_strdup_printf("%i-%02i-%02iT%s", year, month, day, timestring);
+	} else {
+		verified_timestring = g_strdup(timestring);
+	}
+
+	GDateTime *msg_time = g_date_time_new_from_iso8601(verified_timestring, local_time);
+	printf("%s \n", g_date_time_format_iso8601(msg_time));
+
+	g_free(verified_timestring);
+
+	if (msg_time == NULL) {
+		return 0;
+	}
+
+	if (g_date_time_difference(msg_time, now) > 0) {
+		// msg_time is in the future, user is probably up past midnight
+		GDateTime *temp = g_date_time_add_days(msg_time, -1);
+		g_date_time_unref(msg_time);
+		msg_time = temp;
+
+		if (g_date_time_difference(msg_time, now) > 0)
+			return 0;
+	}
+
+	timestamp = g_date_time_to_unix(msg_time);
+
+	g_time_zone_unref(local_time);
+	g_date_time_unref(msg_time);
+	return timestamp;
+}
+
 static void
 discord_got_pinned(DiscordAccount *da, JsonNode *node, gpointer user_data)
 {
@@ -7662,26 +7720,41 @@ discord_reply_cb(DiscordAccount *da, JsonNode *node, gpointer user_data)
 
 }
 
-static PurpleCmdRet
-discord_cmd_reply(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar **error, gpointer data)
+static gchar *
+discord_get_message_id_from_timestamp(PurpleConversation *conv, const gchar *timestamp)
 {
-	PurpleConnection *pc = purple_conversation_get_connection(conv);
-	DiscordAccount *da = purple_connection_get_protocol_data(pc);
-	guint64 room_id = *(guint64 *) purple_conversation_get_data(conv, "id");
-	gint ret;
+  time_t msg_time = discord_parse_timestamp(timestamp);
 
-	if (pc == NULL || (int)room_id == -1) {
-		return PURPLE_CMD_RET_FAILED;
+	if (!msg_time) {
+		return NULL;
 	}
 
-	//gchar **parts = g_strsplit(args[0], " ", 2);
-	gchar *msg_txt = g_strdup(args[1]);
+  GList *msg_list = conv->message_history;
+  GList *msg_elem = g_list_find_custom(msg_list, &msg_time, (GCompareFunc)discord_msg_time_comp);
+  PurpleConvMessage *msg = msg_elem->data;
 
+  if (msg == NULL) {
+    return NULL;
+  }
+
+	const gchar *text = g_strrstr(msg->what, "dscmsg:");
+	g_return_val_if_fail(text && strlen(text) > DSCMSGSIZE, FALSE);
+	return g_strndup((char*)text + DSCMSGSIZE, 18);
+}
+
+static gboolean
+discord_chat_reply(DiscordAccount *da, PurpleConversation *conv, guint64 room_id, gchar **args)
+{
+
+	gchar *msg_txt = g_strdup(args[1]);
+	gchar *msg_id;
+	gint ret;
 
 	DiscordGuild *guild = NULL;
-	DiscordChannel *channel = discord_get_channel_global_int_guild(da, room_id, &guild);
-	guint64 last_message = channel->last_message_id;
+	//DiscordChannel *channel = discord_get_channel_global_int_guild(da, room_id, &guild);
+	discord_get_channel_global_int_guild(da, room_id, &guild);
 
+	/* Format outgoing message */
 	msg_txt = discord_make_mentions(da, guild, msg_txt);
 
 	if(guild) {
@@ -7693,9 +7766,21 @@ discord_cmd_reply(PurpleConversation *conv, const gchar *cmd, gchar **args, gcha
 		}
 	}
 
-	g_return_val_if_fail(discord_get_channel_global_int(da, room_id), -1); /* TODO rejoin room? */
+	g_return_val_if_fail(discord_get_channel_global_int(da, room_id), FALSE); /* TODO rejoin room? */
 
-	ret = discord_conversation_send_message(da, room_id, msg_txt, args[0]);
+	/* Get referenced message id */
+	if (strchr(args[0], ':')) {
+		msg_id = discord_get_message_id_from_timestamp(conv, args[0]);
+		if (msg_id == 0) {
+			g_free(msg_txt);
+			return FALSE;
+		}
+	} else {
+		msg_id = g_strdup(args[0]);
+	}
+
+	/* Send message */
+	ret = discord_conversation_send_message(da, room_id, msg_txt, msg_id);
 	if (ret > 0) {
 
 		DiscordReply *reply = g_new0(DiscordReply, 1);
@@ -7703,29 +7788,23 @@ discord_cmd_reply(PurpleConversation *conv, const gchar *cmd, gchar **args, gcha
 		reply->msg_txt = g_strdup(msg_txt);
 		reply->conv = conv;
 
-		gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/" DISCORD_API_VERSION "/channels/%" G_GUINT64_FORMAT "/messages?limit=5&after=%" G_GUINT64_FORMAT, room_id, last_message-1);
+		gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/" DISCORD_API_VERSION "/channels/%" G_GUINT64_FORMAT "/messages?limit=5&after=%" G_GUINT64_FORMAT, room_id, to_int(msg_id)-1);
 		discord_fetch_url(da, url, NULL, discord_reply_cb, reply);
 		g_free(url);
 	}
 
 	g_free(msg_txt);
+	g_free(msg_id);
 
-	return PURPLE_CMD_RET_OK;
+	return TRUE;
 }
 
-static PurpleCmdRet
-discord_cmd_react(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar **error, gpointer data)
+static gboolean
+discord_chat_react(DiscordAccount *da, PurpleConversation *conv, guint64 id, gchar **args)
 {
-	PurpleConnection *pc = purple_conversation_get_connection(conv);
-	DiscordAccount *da = purple_connection_get_protocol_data(pc);
-	guint64 id = *(guint64 *) purple_conversation_get_data(conv, "id");
-
-	if (pc == NULL || id == -1) {
-		return PURPLE_CMD_RET_FAILED;
-	}
-
 	//gchar **parts = g_strsplit(args[0], " ", -1);
 
+	gchar *msg_id;
 	const gchar *raw_emoji = args[1];
 	gchar *emoji = NULL;
 	if (g_str_has_prefix(raw_emoji, ":") && g_str_has_suffix(raw_emoji, ":")) {
@@ -7747,11 +7826,61 @@ discord_cmd_react(PurpleConversation *conv, const gchar *cmd, gchar **args, gcha
 		emoji = tmp;
 	}
 
-	gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/" DISCORD_API_VERSION "/channels/%" G_GUINT64_FORMAT "/messages/%s/reactions/%s/%%40me", id, args[0], purple_url_encode(emoji));
+	/* Get referenced message id */
+	if (strchr(args[0], ':')) {
+		msg_id = discord_get_message_id_from_timestamp(conv, args[0]);
+		if (msg_id == 0) {
+			return FALSE;
+		}
+	} else {
+		msg_id = g_strdup(args[0]);
+	}
+
+	gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/" DISCORD_API_VERSION "/channels/%" G_GUINT64_FORMAT "/messages/%s/reactions/%s/%%40me", id, msg_id, purple_url_encode(emoji));
 	discord_fetch_url_with_method(da, "PUT", url, "{}", NULL, NULL);
 	g_free(url);
+	g_free(msg_id);
+	return TRUE;
 
-	return PURPLE_CMD_RET_OK;
+}
+
+static PurpleCmdRet
+discord_cmd_reply(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar **error, gpointer data)
+{
+	PurpleConnection *pc = purple_conversation_get_connection(conv);
+	DiscordAccount *da = purple_connection_get_protocol_data(pc);
+	guint64 room_id = *(guint64 *) purple_conversation_get_data(conv, "id");
+
+	if (pc == NULL || (int)room_id == -1) {
+		return PURPLE_CMD_RET_FAILED;
+	}
+
+	gboolean is_okay = discord_chat_reply(da, conv, room_id, args);
+
+	if (is_okay)
+		return PURPLE_CMD_RET_OK;
+	else
+		return PURPLE_CMD_RET_FAILED;
+}
+
+static PurpleCmdRet
+discord_cmd_react(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar **error, gpointer data)
+{
+	PurpleConnection *pc = purple_conversation_get_connection(conv);
+	DiscordAccount *da = purple_connection_get_protocol_data(pc);
+	guint64 id = *(guint64 *) purple_conversation_get_data(conv, "id");
+
+	if (pc == NULL || id == -1) {
+		return PURPLE_CMD_RET_FAILED;
+	}
+
+
+	gboolean is_okay = discord_chat_react(da, conv, id, args);
+
+	if (is_okay)
+		return PURPLE_CMD_RET_OK;
+	else
+		return PURPLE_CMD_RET_FAILED;
 }
 
 static PurpleCmdRet
@@ -7861,14 +7990,14 @@ plugin_load(PurplePlugin *plugin, GError **error)
 		"reply", "ws", PURPLE_CMD_P_PLUGIN,
 		PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
 		DISCORD_PLUGIN_ID, discord_cmd_reply,
-		_("reply <msg_id> <message>:  Replies to message"), NULL
+		_("reply <msg_id> <message> or reply <timestamp> <message>:  Replies to message"), NULL
 	);
 
 	purple_cmd_register(
 		"react", "ws", PURPLE_CMD_P_PLUGIN,
 		PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
 		DISCORD_PLUGIN_ID, discord_cmd_react,
-		_("react <msg_id> <emoji>:  Reacts to message with emoji"), NULL
+		_("react <msg_id> <emoji> pr react <timestamp> <emoji>:  Reacts to message with emoji"), NULL
 	);
 
 	purple_cmd_register(
@@ -7919,6 +8048,7 @@ plugin_load(PurplePlugin *plugin, GError **error)
 		DISCORD_PLUGIN_ID, discord_cmd_roles,
 		_("roles:  Display server roles"), NULL
 	);
+
 
 
 #if 0

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2219,6 +2219,13 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 		escaped_content = tmp;
 	}
 
+	if (purple_account_get_bool(da->account, "show-msg-id", FALSE)) {
+		/* Add msg_id */
+		tmp = g_strdup_printf("%s <a href=\"dscmsg:%ld\"><font size=1>.</font></a>", escaped_content, msg_id);
+		g_free(escaped_content);
+		escaped_content = tmp;
+	}
+
 	if (embeds != NULL) {
 		GString *embed_str = g_string_new(NULL);
 		guint embeds_len = json_array_get_length(embeds);
@@ -6676,7 +6683,7 @@ discord_conversation_check_message_for_images(DiscordAccount *da, guint64 room_i
 }
 
 static gint
-discord_conversation_send_message(DiscordAccount *da, guint64 room_id, const gchar *message)
+discord_conversation_send_message(DiscordAccount *da, guint64 room_id, const gchar *message, const gchar *ref_id)
 {
 	JsonObject *data = json_object_new();
 	gchar *nonce;
@@ -6707,6 +6714,12 @@ discord_conversation_send_message(DiscordAccount *da, guint64 room_id, const gch
 		json_object_set_string_member(data, "content", final);
 		json_object_set_string_member(data, "nonce", nonce);
 		json_object_set_boolean_member(data, "tts", FALSE);
+
+		if (ref_id != NULL) {
+			JsonObject *ref_obj = json_object_new();
+			json_object_set_string_member(ref_obj, "message_id", ref_id);
+			json_object_set_object_member(data, "message_reference", ref_obj);
+		}
 
 		g_hash_table_insert(da->sent_message_ids, nonce, nonce);
 
@@ -6771,7 +6784,7 @@ discord_chat_send(PurpleConnection *pc, gint id,
 	}
 
 	g_return_val_if_fail(discord_get_channel_global_int(da, room_id), -1); /* TODO rejoin room? */
-	ret = discord_conversation_send_message(da, room_id, d_message);
+	ret = discord_conversation_send_message(da, room_id, d_message, NULL);
 
 	if (ret > 0) {
 		gchar *tmp = g_regex_replace_eval(emoji_regex, d_message, -1, 0, 0, discord_replace_emoji, PURPLE_CONVERSATION(chatconv), NULL);
@@ -6835,7 +6848,7 @@ discord_created_direct_message_send(DiscordAccount *da, JsonNode *node, gpointer
 	}
 
 	if (room_id != NULL) {
-		discord_conversation_send_message(da, to_int(room_id), message);
+		discord_conversation_send_message(da, to_int(room_id), message, NULL);
 	} else {
 		purple_conversation_present_error(who, da->account, _("Invalid channel for this user"));
 	}
@@ -6885,7 +6898,7 @@ discord_send_im(PurpleConnection *pc,
 		return -1;
 	}
 
-	return discord_conversation_send_message(da, to_int(room_id), message);
+	return discord_conversation_send_message(da, to_int(room_id), message, NULL);
 }
 
 static void
@@ -7506,6 +7519,9 @@ discord_add_account_options(GList *account_options)
 	option = purple_account_option_bool_new(_("Display custom emoji as inline images"), "show-custom-emojis", TRUE);
 	account_options = g_list_append(account_options, option);
 
+	option = purple_account_option_bool_new(_("Append small link with message id to incoming messages"), "show-msg-id", TRUE);
+	account_options = g_list_append(account_options, option);
+
 	option = purple_account_option_bool_new(_("Open chat when you are @mention'd"), "open-chat-on-mention", TRUE);
 	account_options = g_list_append(account_options, option);
 
@@ -7575,6 +7591,167 @@ discord_actions(
 	m = g_list_append(m, act);
 
 	return m;
+}
+
+typedef struct {
+	guint64 room_id;
+	gchar *msg_txt;
+	PurpleConversation *conv;
+} DiscordReply;
+
+static void
+discord_reply_cb(DiscordAccount *da, JsonNode *node, gpointer user_data)
+{
+	DiscordReply *reply = user_data;
+	gchar *msg_txt = reply->msg_txt;
+	guint64 room_id = reply->room_id;
+	PurpleConversation *conv = reply->conv;
+
+	PurpleConnection *pc = purple_conversation_get_connection(conv);
+
+	DiscordGuild *guild = NULL;
+	DiscordChannel *channel = discord_get_channel_global_int_guild(da, room_id, &guild);
+
+	JsonArray *messages = json_node_get_array(node);
+	guint len = json_array_get_length(messages);
+	JsonObject *referenced_message = json_array_get_object_element(messages, len-1);
+	JsonObject *reply_author = json_object_get_object_member(referenced_message, "author");
+	const gchar *reply_txt = json_object_get_string_member(referenced_message, "content");
+	DiscordUser *reply_user = discord_upsert_user(da->new_users, reply_author);
+	const gchar *reply_username = discord_create_fullname(reply_user);
+
+	size_t txt_len = g_utf8_strlen(reply_txt, -1);
+	gchar *prev_text;
+
+	// Truncate long messages
+	if (txt_len > 32) {
+		// Get pointer to 33th character of msg_text
+		gchar *tmp = g_utf8_offset_to_pointer(reply_txt, 32);
+		// (tmp - reply_txt) is # bytes (char*) of first 32 characters
+		guint num_bytes = tmp - reply_txt;
+		tmp = g_strndup(reply_txt, num_bytes);
+		prev_text = g_strdup_printf("%s...", tmp);
+		g_free(tmp);
+	} else {
+		prev_text = g_strdup(reply_txt);
+	}
+
+	gchar *reply_msg = g_strdup_printf("<font size=1>┌──@%s: %s</font>", reply_username, prev_text);
+	g_free(prev_text);
+
+	purple_conversation_write(conv, NULL, reply_msg, PURPLE_MESSAGE_SYSTEM, time(NULL));
+	g_free(reply_msg);
+
+	gchar *tmp = g_regex_replace_eval(emoji_regex, msg_txt, -1, 0, 0, discord_replace_emoji, conv, NULL);
+
+	if (tmp != NULL) {
+		g_free(msg_txt);
+		msg_txt = tmp;
+	}
+
+	msg_txt = discord_replace_mentions_bare(da, guild, msg_txt);
+
+	if (guild) {
+		gchar *name = discord_create_nickname_from_id(da, guild, channel, da->self_user_id);
+		purple_serv_got_chat_in(pc, discord_chat_hash(room_id), name, PURPLE_MESSAGE_SEND, msg_txt, time(NULL));
+		g_free(name);
+	}
+
+	g_free(reply);
+	g_free(msg_txt);
+
+}
+
+static PurpleCmdRet
+discord_cmd_reply(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar **error, gpointer data)
+{
+	PurpleConnection *pc = purple_conversation_get_connection(conv);
+	DiscordAccount *da = purple_connection_get_protocol_data(pc);
+	guint64 room_id = *(guint64 *) purple_conversation_get_data(conv, "id");
+	gint ret;
+
+	if (pc == NULL || (int)room_id == -1) {
+		return PURPLE_CMD_RET_FAILED;
+	}
+
+	//gchar **parts = g_strsplit(args[0], " ", 2);
+	gchar *msg_txt = g_strdup(args[1]);
+
+
+	DiscordGuild *guild = NULL;
+	DiscordChannel *channel = discord_get_channel_global_int_guild(da, room_id, &guild);
+	guint64 last_message = channel->last_message_id;
+
+	msg_txt = discord_make_mentions(da, guild, msg_txt);
+
+	if(guild) {
+		gchar *tmp = g_regex_replace_eval(emoji_natural_regex, msg_txt, -1, 0, 0, discord_replace_natural_emoji, guild, NULL);
+
+		if (tmp != NULL) {
+			g_free(msg_txt);
+			msg_txt = tmp;
+		}
+	}
+
+	g_return_val_if_fail(discord_get_channel_global_int(da, room_id), -1); /* TODO rejoin room? */
+
+	ret = discord_conversation_send_message(da, room_id, msg_txt, args[0]);
+	if (ret > 0) {
+
+		DiscordReply *reply = g_new0(DiscordReply, 1);
+		reply->room_id = room_id;
+		reply->msg_txt = g_strdup(msg_txt);
+		reply->conv = conv;
+
+		gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/" DISCORD_API_VERSION "/channels/%" G_GUINT64_FORMAT "/messages?limit=5&after=%" G_GUINT64_FORMAT, room_id, last_message-1);
+		discord_fetch_url(da, url, NULL, discord_reply_cb, reply);
+		g_free(url);
+	}
+
+	g_free(msg_txt);
+
+	return PURPLE_CMD_RET_OK;
+}
+
+static PurpleCmdRet
+discord_cmd_react(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar **error, gpointer data)
+{
+	PurpleConnection *pc = purple_conversation_get_connection(conv);
+	DiscordAccount *da = purple_connection_get_protocol_data(pc);
+	guint64 id = *(guint64 *) purple_conversation_get_data(conv, "id");
+
+	if (pc == NULL || id == -1) {
+		return PURPLE_CMD_RET_FAILED;
+	}
+
+	//gchar **parts = g_strsplit(args[0], " ", -1);
+
+	const gchar *raw_emoji = args[1];
+	gchar *emoji = NULL;
+	if (g_str_has_prefix(raw_emoji, ":") && g_str_has_suffix(raw_emoji, ":")) {
+		gchar **emoji_parts = g_strsplit(args[1], ":", -1);
+		emoji = g_strdup(emoji_parts[1]);
+		g_strfreev(emoji_parts);
+	} else {
+		emoji = g_strdup(raw_emoji);
+	}
+
+	DiscordGuild *guild = NULL;
+	discord_get_channel_global_int_guild(da, id, &guild);
+	gchar *emoji_id = g_hash_table_lookup(guild->emojis, emoji);
+
+	if (emoji_id != NULL) {
+		gchar *tmp = g_strdup_printf("%s:%s", emoji, emoji_id);
+		if (emoji != NULL)
+			g_free(emoji);
+		emoji = tmp;
+	}
+
+	gchar *url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/" DISCORD_API_VERSION "/channels/%" G_GUINT64_FORMAT "/messages/%s/reactions/%s/%%40me", id, args[0], purple_url_encode(emoji));
+	discord_fetch_url_with_method(da, "PUT", url, "{}", NULL, NULL);
+	g_free(url);
+
+	return PURPLE_CMD_RET_OK;
 }
 
 static PurpleCmdRet
@@ -7681,6 +7858,20 @@ plugin_load(PurplePlugin *plugin, GError **error)
 	discord_spaced_mention_regex = g_regex_new("(?:^|\\s)@([^\\s@]+ [^\\s@]+)\\b", G_REGEX_OPTIMIZE, 0, NULL);
 
 	purple_cmd_register(
+		"reply", "ws", PURPLE_CMD_P_PLUGIN,
+		PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
+		DISCORD_PLUGIN_ID, discord_cmd_reply,
+		_("reply <msg_id> <message>:  Replies to message"), NULL
+	);
+
+	purple_cmd_register(
+		"react", "ws", PURPLE_CMD_P_PLUGIN,
+		PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
+		DISCORD_PLUGIN_ID, discord_cmd_react,
+		_("react <msg_id> <emoji>:  Reacts to message with emoji"), NULL
+	);
+
+	purple_cmd_register(
 		"nick", "s", PURPLE_CMD_P_PLUGIN,
 		PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
 		DISCORD_PLUGIN_ID, discord_cmd_nick,
@@ -7728,7 +7919,6 @@ plugin_load(PurplePlugin *plugin, GError **error)
 		DISCORD_PLUGIN_ID, discord_cmd_roles,
 		_("roles:  Display server roles"), NULL
 	);
-
 
 
 #if 0


### PR DESCRIPTION
This is a _very_ bare-bones implementation of outgoing replies and reactions. I don't expect this to get merged, but I wanted to make my work available to others.

This adds a user setting to append a small period containing a link of format `dscmsg:[message id]`, which can then be copied for use in a slash command such as `/reply [message id] [your message content]` or `/react [message id] [emoji]`.

I didn't want to add the gui dependencies to purple-discord proper, so I initiated the `dscmsg` protocol in a separate repo at [dlmarquis/pidgin-discordhelper](https://github.com/dlmarquis/pidgin-discordhelper). This makes the small links clickable, and clicking them copies the message id to the clipboard.

Replying and reacting are currently only enabled for chats, because implementing them for dms was going to be a lot more work.

I've been using this for a while, and it works very well. It occasionally shows the wrong message preview for a replied-to message when I reply to a message from my log history and not the current session, but that's about it for bugs I've noticed.

EDIT 04OCT2021: I added timestamp support that works with the tiny links added to messages. I'm fairly sure it picks up the _last_ message at a given timestamp, if you manage to have multiple. No support for changing that yet.

As long as we're confident our timestamp code works now, I can also have it just pull messages from the server based on the timestamp -> message id conversion.