### PR TITLE
Threads, reacts, replies, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ Requires devel headers/libs for libpurple and libjson-glib [libglib2.0-dev, libj
 	sudo make install
 ```
 
+Slash Commands
+--------------
+Purple-discord supports the following slash commands:
+
+| Command | Usage | Description |
+| ------- | ----- | ----------- |
+| nick | `/nick <new nickname>` | Changes nickname on a server. |
+| kick | `/kick <username>` | Remove someone from a server. |
+| ban | `/ban <username>` | Remove someone from a server and prevent them from rejoining. |
+| leave | `/leave` | Leave the channel. |
+| part | `/part`  | Leave the channel. |
+| pinned | `/pinned` | Display pinned messages. |
+| roles | `/roles` | Display server roles. |
+| threads | `/threads` | Display active channel threads. |
+| thread | `/thread <timestamp> <message>` | Sends message to thread. |
+| react | `/react <timestamp> <emoji>` | Reacts to message at timestamp with emoji. |
+| reply | `/reply <timestamp> <message>` | Replies to message at timestamp. |
+
 Advanced Options
 ----------------
 **Use status message as in-game info**: If enabled, the status message set via
@@ -74,9 +92,29 @@ This value is the threshold to define a large channel. By default, if
 there are more than 80 (online) users in the channel, it will be
 considered large.
 
+**Display images in conversations**: Automatically downloads attached images
+and displays them in DMs and small channels.
+
+**Display images in large servers**: Like above, but for large channels. Needs
+<Display images in conversations> to be turned on to work.
+
+**Max displayed image width (0 disables)**: The maximum image width to download
+when <Display images in conversations> is turned on. Plugin will fetch a smaller
+version of the image if it is too large.
+
 **Display custom emoji as inline images**: Automatically downloads custom
 emoji from the server and displays it in Pidgin as an inline image instead
-of as a URL link
+of as a URL link.
+
+**Fetch unread chat messages when account connects**: Experimental. Attempts to
+open and populate server channels at start based on your mention settings.
+
+**Indicate thread replies with this prefix**: Sets the prefix used to indicate a
+thread reply. Thread replies will be formatted as `[user-set prefix][thread
+timestamp]: [message]`.
+
+**Indicate thread parent messages with this prefix**: As above, but for the
+first/parent message of a thread.
 
 Mentions
 --------

--- a/gdatetime_fromiso.h
+++ b/gdatetime_fromiso.h
@@ -1,0 +1,345 @@
+// From https://github.com/GNOME/glib/blob/2.56.4/glib/gdatetime.c
+
+#include <glib.h>
+#include <stdlib.h>
+#include <string.h>
+//#include <sys/time.h>
+#include <time.h>
+
+#define GREGORIAN_LEAP(y)    ((((y) % 4) == 0) && (!((((y) % 100) == 0) && (((y) % 400) != 0))))
+
+/* Parse integers in the form d (week days), dd (hours etc), ddd (ordinal days) or dddd (years) */
+static gboolean
+get_iso8601_int (const gchar *text, gsize length, gint *value)
+{
+  gint i, v = 0;
+
+  if (length < 1 || length > 4)
+    return FALSE;
+
+  for (i = 0; i < length; i++)
+    {
+      const gchar c = text[i];
+      if (c < '0' || c > '9')
+        return FALSE;
+      v = v * 10 + (c - '0');
+    }
+
+  *value = v;
+  return TRUE;
+}
+
+/* Parse seconds in the form ss or ss.sss (variable length decimal) */
+static gboolean
+get_iso8601_seconds (const gchar *text, gsize length, gdouble *value)
+{
+  gint i;
+  gdouble divisor = 1, v = 0;
+
+  if (length < 2)
+    return FALSE;
+
+  for (i = 0; i < 2; i++)
+    {
+      const gchar c = text[i];
+      if (c < '0' || c > '9')
+        return FALSE;
+      v = v * 10 + (c - '0');
+    }
+
+  if (length > 2 && !(text[i] == '.' || text[i] == ','))
+    return FALSE;
+  i++;
+  if (i == length)
+    return FALSE;
+
+  for (; i < length; i++)
+    {
+      const gchar c = text[i];
+      if (c < '0' || c > '9')
+        return FALSE;
+      v = v * 10 + (c - '0');
+      divisor *= 10;
+    }
+
+  *value = v / divisor;
+  return TRUE;
+}
+
+static GDateTime *
+g_date_time_new_ordinal (GTimeZone *tz, gint year, gint ordinal_day, gint hour, gint minute, gdouble seconds)
+{
+  GDateTime *dt;
+
+  if (ordinal_day < 1 || ordinal_day > (GREGORIAN_LEAP (year) ? 366 : 365))
+    return NULL;
+
+  dt = g_date_time_new (tz, year, 1, 1, hour, minute, seconds);
+  dt->days += ordinal_day - 1;
+
+  return dt;
+}
+
+static GDateTime *
+g_date_time_new_week (GTimeZone *tz, gint year, gint week, gint week_day, gint hour, gint minute, gdouble seconds)
+{
+  gint64 p;
+  gint max_week, jan4_week_day, ordinal_day;
+  GDateTime *dt;
+
+  p = (year * 365 + (year / 4) - (year / 100) + (year / 400)) % 7;
+  max_week = p == 4 ? 53 : 52;
+
+  if (week < 1 || week > max_week || week_day < 1 || week_day > 7)
+    return NULL;
+
+  dt = g_date_time_new (tz, year, 1, 4, 0, 0, 0);
+  g_date_time_get_week_number (dt, NULL, &jan4_week_day, NULL);
+  ordinal_day = (week * 7) + week_day - (jan4_week_day + 3);
+  if (ordinal_day < 0)
+    {
+      year--;
+      ordinal_day += GREGORIAN_LEAP (year) ? 366 : 365;
+    }
+  else if (ordinal_day > (GREGORIAN_LEAP (year) ? 366 : 365))
+    {
+      ordinal_day -= (GREGORIAN_LEAP (year) ? 366 : 365);
+      year++;
+    }
+
+  return g_date_time_new_ordinal (tz, year, ordinal_day, hour, minute, seconds);
+}
+
+static GDateTime *
+parse_iso8601_date (const gchar *text, gsize length,
+                    gint hour, gint minute, gdouble seconds, GTimeZone *tz)
+{
+  /* YYYY-MM-DD */
+  if (length == 10 && text[4] == '-' && text[7] == '-')
+    {
+      int year, month, day;
+      if (!get_iso8601_int (text, 4, &year) ||
+          !get_iso8601_int (text + 5, 2, &month) ||
+          !get_iso8601_int (text + 8, 2, &day))
+        return NULL;
+      return g_date_time_new (tz, year, month, day, hour, minute, seconds);
+    }
+  /* YYYY-DDD */
+  else if (length == 8 && text[4] == '-')
+    {
+      gint year, ordinal_day;
+      if (!get_iso8601_int (text, 4, &year) ||
+          !get_iso8601_int (text + 5, 3, &ordinal_day))
+        return NULL;
+      return g_date_time_new_ordinal (tz, year, ordinal_day, hour, minute, seconds);
+    }
+  /* YYYY-Www-D */
+  else if (length == 10 && text[4] == '-' && text[5] == 'W' && text[8] == '-')
+    {
+      gint year, week, week_day;
+      if (!get_iso8601_int (text, 4, &year) ||
+          !get_iso8601_int (text + 6, 2, &week) ||
+          !get_iso8601_int (text + 9, 1, &week_day))
+        return NULL;
+      return g_date_time_new_week (tz, year, week, week_day, hour, minute, seconds);
+    }
+  /* YYYYWwwD */
+  else if (length == 8 && text[4] == 'W')
+    {
+      gint year, week, week_day;
+      if (!get_iso8601_int (text, 4, &year) ||
+          !get_iso8601_int (text + 5, 2, &week) ||
+          !get_iso8601_int (text + 7, 1, &week_day))
+        return NULL;
+      return g_date_time_new_week (tz, year, week, week_day, hour, minute, seconds);
+    }
+  /* YYYYMMDD */
+  else if (length == 8)
+    {
+      int year, month, day;
+      if (!get_iso8601_int (text, 4, &year) ||
+          !get_iso8601_int (text + 4, 2, &month) ||
+          !get_iso8601_int (text + 6, 2, &day))
+        return NULL;
+      return g_date_time_new (tz, year, month, day, hour, minute, seconds);
+    }
+  /* YYYYDDD */
+  else if (length == 7)
+    {
+      gint year, ordinal_day;
+      if (!get_iso8601_int (text, 4, &year) ||
+          !get_iso8601_int (text + 4, 3, &ordinal_day))
+        return NULL;
+      return g_date_time_new_ordinal (tz, year, ordinal_day, hour, minute, seconds);
+    }
+  else
+    return FALSE;
+}
+
+static GTimeZone *
+parse_iso8601_timezone (const gchar *text, gsize length, gssize *tz_offset)
+{
+  gint i, tz_length, offset_sign = 1, offset_hours, offset_minutes;
+  GTimeZone *tz;
+
+  /* UTC uses Z suffix  */
+  if (length > 0 && text[length - 1] == 'Z')
+    {
+      *tz_offset = length - 1;
+      return g_time_zone_new_utc ();
+    }
+
+  /* Look for '+' or '-' of offset */
+  for (i = length - 1; i >= 0; i--)
+    if (text[i] == '+' || text[i] == '-')
+      {
+        offset_sign = text[i] == '-' ? -1 : 1;
+        break;
+      }
+  if (i < 0)
+    return NULL;
+  tz_length = length - i;
+
+  /* +hh:mm or -hh:mm */
+  if (tz_length == 6 && text[i+3] == ':')
+    {
+      if (!get_iso8601_int (text + i + 1, 2, &offset_hours) ||
+          !get_iso8601_int (text + i + 4, 2, &offset_minutes))
+        return NULL;
+    }
+  /* +hhmm or -hhmm */
+  else if (tz_length == 5)
+    {
+      if (!get_iso8601_int (text + i + 1, 2, &offset_hours) ||
+          !get_iso8601_int (text + i + 3, 2, &offset_minutes))
+        return NULL;
+    }
+  /* +hh or -hh */
+  else if (tz_length == 3)
+    {
+      if (!get_iso8601_int (text + i + 1, 2, &offset_hours))
+        return NULL;
+      offset_minutes = 0;
+    }
+  else
+    return NULL;
+
+  *tz_offset = i;
+  tz = g_time_zone_new (text + i);
+
+  /* Double-check that the GTimeZone matches our interpretation of the timezone.
+   * Failure would indicate a bug either here of in the GTimeZone code. */
+  g_assert (g_time_zone_get_offset (tz, 0) == offset_sign * (offset_hours * 3600 + offset_minutes * 60));
+
+  return tz;
+}
+
+static gboolean
+parse_iso8601_time (const gchar *text, gsize length,
+                    gint *hour, gint *minute, gdouble *seconds, GTimeZone **tz)
+{
+  gssize tz_offset = -1;
+
+  /* Check for timezone suffix */
+  *tz = parse_iso8601_timezone (text, length, &tz_offset);
+  if (tz_offset >= 0)
+    length = tz_offset;
+
+  /* hh:mm:ss(.sss) */
+  if (length >= 8 && text[2] == ':' && text[5] == ':')
+    {
+      return get_iso8601_int (text, 2, hour) &&
+             get_iso8601_int (text + 3, 2, minute) &&
+             get_iso8601_seconds (text + 6, length - 6, seconds);
+    }
+  /* hhmmss(.sss) */
+  else if (length >= 6)
+    {
+      return get_iso8601_int (text, 2, hour) &&
+             get_iso8601_int (text + 2, 2, minute) &&
+             get_iso8601_seconds (text + 4, length - 4, seconds);
+    }
+  else
+    return FALSE;
+}
+
+/**
+ * g_date_time_new_from_iso8601:
+ * @text: an ISO 8601 formatted time string.
+ * @default_tz: (nullable): a #GTimeZone to use if the text doesn't contain a
+ *                          timezone, or %NULL.
+ *
+ * Creates a #GDateTime corresponding to the given
+ * [ISO 8601 formatted string](https://en.wikipedia.org/wiki/ISO_8601)
+ * @text. ISO 8601 strings of the form <date><sep><time><tz> are supported.
+ *
+ * <sep> is the separator and can be either 'T', 't' or ' '.
+ *
+ * <date> is in the form:
+ *
+ * - `YYYY-MM-DD` - Year/month/day, e.g. 2016-08-24.
+ * - `YYYYMMDD` - Same as above without dividers.
+ * - `YYYY-DDD` - Ordinal day where DDD is from 001 to 366, e.g. 2016-237.
+ * - `YYYYDDD` - Same as above without dividers.
+ * - `YYYY-Www-D` - Week day where ww is from 01 to 52 and D from 1-7,
+ *   e.g. 2016-W34-3.
+ * - `YYYYWwwD` - Same as above without dividers.
+ *
+ * <time> is in the form:
+ *
+ * - `hh:mm:ss(.sss)` - Hours, minutes, seconds (subseconds), e.g. 22:10:42.123.
+ * - `hhmmss(.sss)` - Same as above without dividers.
+ *
+ * <tz> is an optional timezone suffix of the form:
+ *
+ * - `Z` - UTC.
+ * - `+hh:mm` or `-hh:mm` - Offset from UTC in hours and minutes, e.g. +12:00.
+ * - `+hh` or `-hh` - Offset from UTC in hours, e.g. +12.
+ *
+ * If the timezone is not provided in @text it must be provided in @default_tz
+ * (this field is otherwise ignored).
+ *
+ * This call can fail (returning %NULL) if @text is not a valid ISO 8601
+ * formatted string.
+ *
+ * You should release the return value by calling g_date_time_unref()
+ * when you are done with it.
+ *
+ * Returns: (transfer full) (nullable): a new #GDateTime, or %NULL
+ *
+ * Since: 2.56
+ */
+GDateTime *
+g_date_time_new_from_iso8601 (const gchar *text, GTimeZone *default_tz)
+{
+  gint length, date_length = -1;
+  gint hour = 0, minute = 0;
+  gdouble seconds = 0.0;
+  GTimeZone *tz = NULL;
+  GDateTime *datetime = NULL;
+
+  g_return_val_if_fail (text != NULL, NULL);
+
+  /* Count length of string and find date / time separator ('T', 't', or ' ') */
+  for (length = 0; text[length] != '\0'; length++)
+    {
+      if (date_length < 0 && (text[length] == 'T' || text[length] == 't' || text[length] == ' '))
+        date_length = length;
+    }
+
+  if (date_length < 0)
+    return NULL;
+
+  if (!parse_iso8601_time (text + date_length + 1, length - (date_length + 1),
+                           &hour, &minute, &seconds, &tz))
+    goto out;
+  if (tz == NULL && default_tz == NULL)
+    return NULL;
+
+  datetime = parse_iso8601_date (text, date_length, hour, minute, seconds, tz ? tz : default_tz);
+
+out:
+    if (tz != NULL)
+      g_time_zone_unref (tz);
+    return datetime;
+}

--- a/glib_compat.h
+++ b/glib_compat.h
@@ -20,6 +20,10 @@
 #include <glib.h>
 #include <purple.h>
 
+#if !GLIB_CHECK_VERSION(2, 56, 0)
+#include "gdatetime_fromiso.h"
+#endif /* 2.56.0 */
+
 #if !GLIB_CHECK_VERSION(2, 32, 0)
 #define g_hash_table_contains(hash_table, key) g_hash_table_lookup_extended(hash_table, key, NULL, NULL)
 #endif /* 2.32.0 */

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2737,13 +2737,10 @@ discord_process_message(DiscordAccount *da, JsonObject *data, unsigned special_t
 					} else {
 						purple_serv_got_chat_in(da->pc, discord_chat_hash(channel_id), name, flags, url_log, timestamp);
 					}
-
 				} else {
 					purple_serv_got_chat_in(da->pc, discord_chat_hash(channel_id), name, flags, url_log, timestamp);
 				}
-
 			}
-
 		}
 
 		if (reactions != NULL) {
@@ -7802,10 +7799,18 @@ discord_reply_cb(DiscordAccount *da, JsonNode *node, gpointer user_data)
 	const gchar *reply_txt = json_object_get_string_member(referenced_message, "content");
 	DiscordUser *reply_user = discord_upsert_user(da->new_users, reply_author);
 	const gchar *reply_username = discord_create_fullname(reply_user);
+	PurpleBuddy *reply_buddy = purple_blist_find_buddy(da->account, reply_username);
+	const gchar *reply_name;
+	if (reply_buddy != NULL) {
+		reply_name = purple_buddy_get_alias(reply_buddy);
+	} else {
+		reply_name = reply_username;
+	}
 
 	gchar *prev_text = discord_truncate_message(reply_txt, 32);
 
-	gchar *reply_msg = g_strdup_printf("<font size=1>┌──@%s: %s</font>", reply_username, prev_text);
+	gchar *reply_msg = g_strdup_printf("<font size=1>┌──@%s: %s</font>", reply_name, prev_text);
+	g_free(reply_username);
 	g_free(prev_text);
 
 	purple_conversation_write(conv, NULL, reply_msg, PURPLE_MESSAGE_SYSTEM, time(NULL));

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -8643,19 +8643,10 @@ discord_cmd_thread(PurpleConversation *conv, const gchar *cmd, gchar **args, gch
 	if (pc == NULL || (int)room_id == -1) {
 		return PURPLE_CMD_RET_FAILED;
 	}
-
-	//gchar *iter;
-	//for (iter = args[0]; *iter != '\0'; iter++) {
-	//}
-
-	gchar *new;
-	if (*args[0] == '<') {
-		new = g_strdup(strchr(args[0], '>') + 1);
-	} else {
-		new = args[0];
+	gchar **parsed_args = discord_parse_wS_args(args);
+	if (parsed_args == NULL) {
+		return PURPLE_CMD_RET_FAILED;
 	}
-
-	gchar **parsed_args = g_strsplit(new, " ", 2);
 
 	gboolean is_okay = discord_chat_thread_reply(da, conv, room_id, parsed_args);
 
@@ -8745,7 +8736,7 @@ plugin_load(PurplePlugin *plugin, GError **error)
 
 	purple_cmd_register(
 		"thread", "S", PURPLE_CMD_P_PLUGIN,
-		PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PROTOCOL_ONLY,
+		PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
 		DISCORD_PLUGIN_ID, discord_cmd_thread,
 		_("thread <timestamp> <message>:  Sends message to thread"), NULL
 	);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2116,11 +2116,12 @@ discord_parse_timestring(const gchar *timestring)
 		g_date_time_unref(msg_time);
 		msg_time = temp;
 
-		if (g_date_time_difference(msg_time, now) > 0)
+		if (g_date_time_difference(msg_time, now) > 0) {
 			g_time_zone_unref(local_time);
 			g_date_time_unref(msg_time);
 			g_date_time_unref(now);
 			return 0;
+		}
 	}
 
 	timestamp = g_date_time_to_unix(msg_time);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -4273,7 +4273,7 @@ discord_is_channel_visible(DiscordAccount *da, DiscordUser *user, DiscordChannel
 		return FALSE;
 
 	/* Drop voice channels since we don't support them anyway */
-	if (channel->type == CHANNEL_VOICE)
+	if (channel->type == CHANNEL_VOICE || channel->type == CHANNEL_GUILD_STAGE_VOICE)
 		return FALSE;
 
 	/* Channel categories become new PurpleGroups so we don't
@@ -4812,7 +4812,7 @@ discord_buddy_guild(DiscordAccount *da, DiscordGuild *guild)
 	DiscordUser *user = discord_get_user(da, da->self_user_id);
 
 	if (!user) {
-		purple_debug_info("discord", "Null user; aborting blist population");
+		purple_debug_info("discord", "Null user; aborting blist population\n");
 		return;
 	}
 
@@ -6776,10 +6776,10 @@ discord_got_channel_info(DiscordAccount *da, JsonNode *node, gpointer user_data)
 
 	if (json_object_has_member(channel, "last_pin_timestamp")) {
 		guint64 last_message_id = discord_get_room_last_id(da, int_id);
-		guint64 last_message_time = ((last_message_id >> 22) + DISCORD_EPOCH_MS)/1000;
+		time_t last_message_time = discord_time_from_snowflake(last_message_id);
 
 		const gchar *last_pin = json_object_get_string_member(channel, "last_pin_timestamp");
-		guint64 pin_time = discord_str_to_time(last_pin);
+		time_t pin_time = discord_str_to_time(last_pin);
 
 		if (pin_time > last_message_time) {
 				purple_conversation_write_system_message(PURPLE_CONVERSATION(chatconv), "This channel's pinned messages have been updated. Type \"/pinned\" to see them.", PURPLE_MESSAGE_SYSTEM);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2169,11 +2169,11 @@ discord_get_thread_color(time_t ts)
 	guint val = (r >>  0) & 255;
 
 	// Make text not black/grey/white
-	if (val < 30) {
-		val |= 30;
+	if (val < 100) {
+		val |= 100;
 	}
-	if (sat < 30) {
-		sat |= 30;
+	if (sat < 75) {
+		sat |= 75;
 	}
 
 	// Formulas taken from Wikipedia:

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -2168,11 +2168,11 @@ discord_get_thread_color(time_t ts)
 	guint val = (r >>  0) & 255;
 
 	// Make text not black/grey/white
-	if (val < 100) {
-		val |= 100;
+	if (val < 110) {
+		val |= 110;
 	}
-	if (sat < 75) {
-		sat |= 75;
+	if (sat < 110) {
+		sat |= 110;
 	}
 
 	// Formulas taken from Wikipedia:

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -8761,7 +8761,7 @@ plugin_load(PurplePlugin *plugin, GError **error)
 			"threads", "", PURPLE_CMD_P_PLUGIN,
 			PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
 						DISCORD_PLUGIN_ID, discord_cmd_threads,
-						_("threads:  Display threads"), NULL
+						_("threads:  Display active channel threads"), NULL
 	);
 
 #if 0


### PR DESCRIPTION
This is a behemoth of a PR, and I apologize for that. Adding support for threads, reactions, and replies all relied on the same core code, so I figured I'd package it all together, and then a few smaller items I was looking at also got absorbed into this PR due to shared code. Let me know if you want me to split things up or reorganize the commits.

Much of the thread code was ripped from and/or inspired by the thread support over at [slack-libpurple](https://github.com/dylex/slack-libpurple).

Threads are shown in their parent channel's chat window, but I have stored them as full channels so that we can support breaking them out into their own entities if we want to in the future.

Attempting to reply or react within a thread should not currently work.