### PR TITLE
Don't store a variable that isn't used before return

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -3685,7 +3685,7 @@ discord_process_dispatch(DiscordAccount *da, const gchar *type, JsonObject *data
 				} else {
 					const gchar *parent_id = json_object_get_string_member(data, "parent_id");
 					DiscordChannel *parent = discord_get_channel_global_int(da, to_int(parent_id));
-					channel = discord_add_thread(da, guild, parent, data, guild->id);
+					discord_add_thread(da, guild, parent, data, guild->id);
 					return;
 				}
 


### PR DESCRIPTION
Suggested-by: scan-build
libdiscord.c:3688:6: warning: Value stored to 'channel' is never read [deadcode.DeadStores]
                                        channel = discord_add_thread(da, guild, parent, data, guild->id);
                                        ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~