### PR TITLE
Don't dereference dchannel pointer without checking for NULL

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -5148,7 +5148,7 @@ discord_got_read_states(DiscordAccount *da, JsonNode *node, gpointer user_data)
 					g_free(tmp);
 
 				} else if (mentions) {
-					purple_debug_misc("discord", "%d unhandled mentions in channel %s\n", mentions, dchannel->name);
+					purple_debug_misc("discord", "%d unhandled mentions in channel %s\n", mentions, dchannel ? dchannel->name : channel);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes crash on startup when there are unhandled mentions in some channels.

Fixes: commit 6e87e9b97ea29dd1d070bec52b6c74b99d543605