### PR TITLE
fixes build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ CFLAGS += -std=c99 -DDISCORD_PLUGIN_VERSION='"$(PLUGIN_VERSION)"' -DMARKDOWN_PID
 # Comment out to disable localisation
 CFLAGS += -DENABLE_NLS
 
+# Comment out to disable
+CFLAGS += -DUSE_QRCODE_AUTH
+
 # Do some nasty OS and purple version detection
 ifeq ($(OS),Windows_NT)
   #only defined on 64-bit windows
@@ -87,20 +90,21 @@ endif
 
 WIN32_CFLAGS = -std=c99 -I$(WIN32_DEV_TOP)/glib-2.28.8/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include/glib-2.0 -I$(WIN32_DEV_TOP)/glib-2.28.8/lib/glib-2.0/include -I$(WIN32_DEV_TOP)/json-glib-0.14/include/json-glib-1.0 -DENABLE_NLS -DDISCORD_PLUGIN_VERSION='"$(PLUGIN_VERSION)"' -DMARKDOWN_PIDGIN -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -fno-strict-aliasing -Wformat
 WIN32_LDFLAGS = -L$(WIN32_DEV_TOP)/glib-2.28.8/lib -L$(WIN32_DEV_TOP)/json-glib-0.14/lib -lpurple -lintl -lglib-2.0 -lgobject-2.0 -ljson-glib-1.0 -g -ggdb -static-libgcc -lz
-WIN32_PIDGIN2_CFLAGS = -I$(PIDGIN_TREE_TOP)/libpurple -I$(PIDGIN_TREE_TOP) $(WIN32_CFLAGS)
-WIN32_PIDGIN3_CFLAGS = -I$(PIDGIN3_TREE_TOP)/libpurple -I$(PIDGIN3_TREE_TOP) -I$(WIN32_DEV_TOP)/gplugin-dev/gplugin $(WIN32_CFLAGS)
-WIN32_PIDGIN2_LDFLAGS = -L$(PIDGIN_TREE_TOP)/libpurple $(WIN32_LDFLAGS)
-WIN32_PIDGIN3_LDFLAGS = -L$(PIDGIN3_TREE_TOP)/libpurple -L$(WIN32_DEV_TOP)/gplugin-dev/gplugin $(WIN32_LDFLAGS) -lgplugin
 
-ifneq ($(USE_QRCODE_AUTH), 0)
+ifneq (,$(findstring -DUSE_QRCODE_AUTH,$(CFLAGS)))
 	WIN32_CFLAGS += -DUSE_QRCODE_AUTH -I$(WIN32_DEV_TOP)/nss-3.24-nspr-4.12/include -I$(WIN32_DEV_TOP)/qrencode-4.1.1
 	WIN32_LDFLAGS += -L$(WIN32_DEV_TOP)/nss-3.24-nspr-4.12/lib -L$(WIN32_DEV_TOP)/qrencode-4.1.1 -lnss3 -lqrencode
 	
 	ifneq ($(OS),Windows_NT)
-		CFLAGS += $(shell ${PKG_CONFIG} --cflags nss libqrencode) -DUSE_QRCODE_AUTH
+		CFLAGS += $(shell ${PKG_CONFIG} --cflags nss libqrencode)
 		LDFLAGS += $(shell ${PKG_CONFIG} --libs nss libqrencode)
 	endif
 endif
+
+WIN32_PIDGIN2_CFLAGS = -I$(PIDGIN_TREE_TOP)/libpurple -I$(PIDGIN_TREE_TOP) $(WIN32_CFLAGS)
+WIN32_PIDGIN3_CFLAGS = -I$(PIDGIN3_TREE_TOP)/libpurple -I$(PIDGIN3_TREE_TOP) -I$(WIN32_DEV_TOP)/gplugin-dev/gplugin $(WIN32_CFLAGS)
+WIN32_PIDGIN2_LDFLAGS = -L$(PIDGIN_TREE_TOP)/libpurple $(WIN32_LDFLAGS)
+WIN32_PIDGIN3_LDFLAGS = -L$(PIDGIN3_TREE_TOP)/libpurple -L$(WIN32_DEV_TOP)/gplugin-dev/gplugin $(WIN32_LDFLAGS) -lgplugin
 
 CFLAGS += -DLOCALEDIR=\"$(LOCALEDIR)\"
 


### PR DESCRIPTION
* It's now possible to disable USE_QRCODE_AUTH.
* QRCODE flags are now inserted into CFLAGS & LDFLAGS (WIN32_PIDGIN).