### PR TITLE
Replace the Fedora/CentOS/RHEL section with a link to Repology

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,11 @@ Windows nightly builds from [here](https://eion.robbmob.com/libdiscord.dll)
 
 The plugin requires libjson-glib which can be downloaded [from github](https://github.com/EionRobb/skype4pidgin/raw/master/skypeweb/libjson-glib-1.0.dll) and copied to the Program Files\Pidgin folder (not the plugins subfolder).
 
-Fedora/CentOS/RHEL
+Linux/BSD
 ---------
-On Fedora you can install [package](https://apps.fedoraproject.org/packages/purple-discord) from Fedora's main repository:
 
-```bash
-	sudo dnf install purple-discord pidgin-discord
-```
-
-On CentOS/RHEL you can install [package](https://apps.fedoraproject.org/packages/purple-discord) from Fedora's [EPEL7](https://fedoraproject.org/wiki/EPEL) repository:
-
-```bash
-	sudo yum install purple-discord pidgin-discord
-```
-
-Thank you to Vitaly Zaitsev for this package.
+The plugin is [available](https://repology.org/project/purple-discord/versions) in the main repositories of many Linux and BSD distros.
+Thanks to the maintainers of all these [packages](https://repology.org/project/purple-discord/packages).
 
 Gentoo
 --------


### PR DESCRIPTION
Repology documents which distros purple-discord is available from.

Keep the Gentoo section because purple-discord isn't available there yet.

Obsoletes: https://github.com/EionRobb/purple-discord/pull/422
