### PR TITLE
Added file upload action

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -9730,10 +9730,7 @@ discord_cmd_get_history(PurpleConversation *conv, const gchar *cmd, gchar **args
 	return PURPLE_CMD_RET_OK;
 }
 
-// TODO positioning
-
-// This function may seem pointless now but if we ever decide to add proper
-// progress indication in the future it may be useful
+// This function may seem pointless now but it might be useful 
 static void
 discord_xfer_finish(PurpleXfer *xfer) {
 	g_free(xfer->data);
@@ -9742,7 +9739,6 @@ discord_xfer_finish(PurpleXfer *xfer) {
 
 // TODO we could do a bunch of other stuff like setting the file size &
 // thumbnail, though that is of questionable utility for an http upload
-
 static void
 discord_xfer_send_init(PurpleXfer *xfer)
 {
@@ -9812,12 +9808,15 @@ discord_xfer_send_init(PurpleXfer *xfer)
 	// help other programs guess at what we're doing
 	purple_xfer_start(xfer, 0, url, 443);
 
-	// TODO we could edit/fork this function to give us progress/completion
-	// notifications, etc
+	// TODO we could edit this function or add our own code for stuff like
+	// progress, completion, the ability to actually cancel the transfer,
+	// etc.
 	discord_fetch_url_with_method_len(da, "POST", url, postdata->str, postdata->len, NULL, NULL);
 
-	purple_xfer_unref(xfer);
+	// TODO We could also wait until we receive the url on our client before
+	// ending our xfer
 	purple_xfer_set_completed(xfer, TRUE);
+	purple_xfer_unref(xfer);
 
 	g_free(filename);
 	g_free(url);
@@ -9845,9 +9844,8 @@ discord_create_xfer(PurpleConnection *pc, guint64 room_id, const gchar *receiver
 	xfer->data = room_id_ptr;
 
 	purple_xfer_set_init_fnc(xfer, discord_xfer_send_init);
-	// TODO check if we need the other functions
 	purple_xfer_set_end_fnc(xfer, discord_xfer_finish);
-	// TODO manually cancelling will NOT stop the xfer
+	// manually canceling the transfer will not actually stop it
 	purple_xfer_set_cancel_send_fnc(xfer, discord_xfer_finish);
 
 	return xfer;
@@ -9869,16 +9867,11 @@ discord_send_file(PurpleConnection *pc, const gchar *who, const gchar *filename)
 
 	PurpleXfer *xfer = discord_create_xfer(pc, room_id, who);
 
-	// TODO do we really need to check for a null byte the way we are
-	// implementing this? I'd assume so, but the jabber prpl doesn't do
-	// this so I better double check
 	if (filename && *filename)
 		purple_xfer_request_accepted(xfer, filename);
 	else
 		purple_xfer_request(xfer);
 }
-
-// TODO should we use the discord hash function for any of this?
 
 static void
 discord_chat_send_file(PurpleConnection *pc, int id, const gchar *filename) {
@@ -9913,8 +9906,9 @@ discord_can_receive_file(PurpleConnection *pc, const gchar *who)
 
 static gboolean
 discord_chat_can_receive_file(PurpleConnection *pc, int id) {
-	// TODO i don't believe there are any checks we can perform here that
-	// aren't better performed later on
+	// As of now, I don't forsee any conditions under which we'd like to
+	// prematurely disable the save function, but I'll leave this here just
+	// in case
 	return TRUE;
 }
 
@@ -10183,8 +10177,6 @@ plugin_init(PurplePlugin *plugin)
 	prpl_info->chat_send_file = discord_chat_send_file;
 	prpl_info->chat_can_receive_file = discord_chat_can_receive_file;
 	prpl_info->can_receive_file = discord_can_receive_file;
-	// TODO ????
-	// prpl_info->new_xfer = discord_new_xfer;
 
 	prpl_info->roomlist_get_list = discord_roomlist_get_list;
 	prpl_info->roomlist_room_serialize = discord_roomlist_serialize;

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -9735,6 +9735,7 @@ discord_cmd_get_history(PurpleConversation *conv, const gchar *cmd, gchar **args
 	return PURPLE_CMD_RET_OK;
 }
 
+#if !PURPLE_VERSION_CHECK(3, 0, 0)
 static void
 discord_xfer_free(PurpleXfer *xfer) {
 	// we only need to free the user data
@@ -10002,6 +10003,7 @@ discord_chat_can_receive_file(PurpleConnection *pc, int id) {
 	// in case
 	return TRUE;
 }
+#endif
 
 static gboolean
 plugin_load(PurplePlugin *plugin, GError **error)
@@ -10264,10 +10266,12 @@ plugin_init(PurplePlugin *plugin)
 	prpl_info->add_deny = discord_block_user;
 	prpl_info->rem_deny = discord_unblock_user;
 
+	#if !PURPLE_VERSION_CHECK(3, 0, 0)
 	prpl_info->send_file = discord_send_file;
 	prpl_info->chat_send_file = discord_chat_send_file;
 	prpl_info->chat_can_receive_file = discord_chat_can_receive_file;
 	prpl_info->can_receive_file = discord_can_receive_file;
+	#endif
 
 	prpl_info->roomlist_get_list = discord_roomlist_get_list;
 	prpl_info->roomlist_room_serialize = discord_roomlist_serialize;

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -8560,6 +8560,93 @@ discord_toggle_mute(PurpleBlistNode *node, gpointer userdata)
 	}
 }
 
+static void 
+discord_send_file_ok_cb(gpointer userdata, const char *fullpath)
+{
+	gchar *filename;
+	gchar *url;
+	gchar *nonce;
+	gchar *contents;
+	GFile *file; 
+	GFileInfo *fileinfo;
+	GString *postdata;
+
+	PurpleBlistNode *node = (PurpleBlistNode *) userdata;
+	PurpleChat *chat = PURPLE_CHAT(node);
+	PurpleAccount *acct = purple_chat_get_account(chat);
+	PurpleConnection *pc = purple_account_get_connection(acct);
+	DiscordAccount *da = purple_connection_get_protocol_data(pc);
+	GHashTable *components = purple_chat_get_components(chat);
+	const gchar *room_id_str = g_hash_table_lookup(components, "id");
+	guint64 room_id = g_ascii_strtoull(room_id_str, NULL, 10);
+
+	GError *load_error = NULL;;
+
+	file = g_file_new_for_path(fullpath);
+	gsize file_len;
+	if (!g_file_load_contents(file, NULL, &contents, &file_len, NULL, &load_error)) {
+		purple_debug_error("discord", "Couldn't load file to send: %s", load_error->message);
+		purple_notify_message(da, PURPLE_NOTIFY_MSG_INFO, _("Could Mot Load File"), _("Check debug messages for more info"), NULL, NULL, NULL);
+		g_free(file);
+		g_free(contents);
+		g_free(load_error);
+		return;
+	}
+	g_free(load_error);
+
+	if (file_len > 25000000) {
+		purple_notify_message(da, PURPLE_NOTIFY_MSG_INFO, _("File Too Large"), _("Maximum file size is 25MB"), NULL, NULL, NULL);
+		g_free(file);
+		g_free(contents);
+		return;
+	}
+
+	filename = g_path_get_basename(fullpath);
+	fileinfo = g_file_query_info(file, "standard::*", 0, NULL, NULL);
+	const gchar *mimetype = g_file_info_get_content_type(fileinfo);
+
+	// We don't insert this into sent messages because that will prevent it
+	// from appearing in our client
+	nonce = g_strdup_printf("%" G_GUINT32_FORMAT, g_random_int());
+
+	postdata = g_string_new(NULL);
+	g_string_append_printf(postdata, "------PurpleBoundary\r\nContent-Disposition: form-data; name=\"file\"; filename=\"%s\"\r\nContent-Type: %s\r\n\r\n", purple_url_encode(filename), mimetype);
+	g_string_append_len(postdata, contents, file_len);
+	g_string_append_printf(postdata, "\r\n------PurpleBoundary\r\nContent-Disposition: form-data; name=\"payload_json\"\r\n\r\n{\"content\":\"\",\"nonce\":\"%s\",\"tts\":false}\r\n", nonce);
+	g_string_append(postdata, "------PurpleBoundary--\r\n");
+
+	url = g_strdup_printf("https://" DISCORD_API_SERVER "/api/" DISCORD_API_VERSION "/channels/%" G_GUINT64_FORMAT "/messages", room_id);
+
+	discord_fetch_url_with_method_len(da, "POST", url, postdata->str, postdata->len, NULL, NULL);
+
+	g_free(filename);
+	g_free(url);
+	g_free(nonce);
+	g_free(contents);
+	g_free(file);
+	g_free(fileinfo);
+	g_string_free(postdata, TRUE);
+}
+
+static void 
+discord_send_file(PurpleBlistNode *node, gpointer userdata)
+{
+	DiscordAccount *da = (DiscordAccount *) userdata;
+	PurpleChat *chat = PURPLE_CHAT(node);
+	PurpleAccount *acct = purple_chat_get_account(chat);
+	PurpleConnection *pc = purple_account_get_connection(acct);
+	GHashTable *components = purple_chat_get_components(chat);
+	const gchar *id_str = g_hash_table_lookup(components, "id");
+	guint64 id64 = g_ascii_strtoull(id_str, NULL, 10);
+	gint id = discord_chat_hash(id64);
+	const PurpleChatConversation *chatconv = purple_conversations_find_chat(pc, id);
+	PurpleConversation *conv = purple_conv_chat_get_conversation(chatconv);
+
+	const char *title = "Select File To Send";
+
+	purple_request_file(da, title, NULL, FALSE, PURPLE_CALLBACK(discord_send_file_ok_cb), NULL, da->account, NULL, conv, node);
+}
+
 static GList *
 discord_blist_node_menu(PurpleBlistNode *node)
 {
@@ -8604,6 +8691,10 @@ discord_blist_node_menu(PurpleBlistNode *node)
 
 		const char *size_handle_toggles = _("Force Treat as...");
 		act = purple_menu_action_new(size_handle_toggles, NULL, da, m_size);
+		m = g_list_append(m, act);
+
+		const char *send_arbitrary_file = _("Upload File");
+		act = purple_menu_action_new(send_arbitrary_file, PURPLE_CALLBACK(discord_send_file), da, NULL);
 		m = g_list_append(m, act);
 	}
 

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -9730,11 +9730,12 @@ discord_cmd_get_history(PurpleConversation *conv, const gchar *cmd, gchar **args
 	return PURPLE_CMD_RET_OK;
 }
 
-// This function may seem pointless now but it might be useful 
+// This function may seem pointless now but it might be useful later if we
+// decide to implement other features
 static void
-discord_xfer_finish(PurpleXfer *xfer) {
+discord_xfer_free(PurpleXfer *xfer) {
+	// we only need to free the user data
 	g_free(xfer->data);
-	purple_xfer_unref(xfer);
 }
 
 // TODO we could do a bunch of other stuff like setting the file size &
@@ -9844,9 +9845,9 @@ discord_create_xfer(PurpleConnection *pc, guint64 room_id, const gchar *receiver
 	xfer->data = room_id_ptr;
 
 	purple_xfer_set_init_fnc(xfer, discord_xfer_send_init);
-	purple_xfer_set_end_fnc(xfer, discord_xfer_finish);
+	purple_xfer_set_end_fnc(xfer, discord_xfer_free);
 	// manually canceling the transfer will not actually stop it
-	purple_xfer_set_cancel_send_fnc(xfer, discord_xfer_finish);
+	purple_xfer_set_cancel_send_fnc(xfer, discord_xfer_free);
 
 	return xfer;
 }

--- a/purple_compat.h
+++ b/purple_compat.h
@@ -36,6 +36,8 @@
 #include "purple2compat/image.h"
 #include "purple2compat/image-store.h"
 
+#define purple_xfer_get_protocol_data(xfer) ((xfer)->data)
+#define purple_xfer_set_protocol_data(xfer, proto_data) ((xfer)->data = (proto_data))
 #define purple_buddy_get_local_alias  purple_buddy_get_local_buddy_alias
 #define purple_buddy_set_local_alias  purple_blist_alias_buddy
 #define purple_connection_error purple_connection_error_reason


### PR DESCRIPTION
Implimentation of https://github.com/EionRobb/purple-discord/issues/164

Allows users to upload a file of any type to a channel through an action in the "More" menu. The code is pretty similar to that of `discord_conversation_send_image`, we just have to probe for the file's info/contents ourselves because we can't use the `purple_img*` commands. Also the nonce for the file upload is not added so we can see the message on our client (there's probably a way to post a fake message on our client so the user gets instant feedback, but this way the user only sees the file upload if it actually succeeds).

Of course, please let me know if there are any issues with the code or style. I've tested this on my machine and I'm relatively confident there should be no issues with the code if it was merged as-is, but the more eyes the merrier. 