### PR TITLE
Fix ImageMagick 7 deprecation warning by using magick convert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,13 +149,13 @@ install: $(DISCORD_TARGET) install-icons install-locales
 	install -m $(LIB_PERM) -p $(DISCORD_TARGET) $(DISCORD_DEST)
 
 discord16.png: discord-alt-logo.svg
-	magic convert -strip -background none discord-alt-logo.svg -resize 16x16 discord16.png
+	magick convert -strip -background none discord-alt-logo.svg -resize 16x16 discord16.png
 
 discord22.png: discord-alt-logo.svg
-	magic convert -strip -background none discord-alt-logo.svg -resize 22x22 discord22.png
+	magick convert -strip -background none discord-alt-logo.svg -resize 22x22 discord22.png
 
 discord48.png: discord-alt-logo.svg
-	magic convert -strip -background none discord-alt-logo.svg -resize 48x48 discord48.png
+	magick convert -strip -background none discord-alt-logo.svg -resize 48x48 discord48.png
 
 build-icons: discord16.png discord22.png discord48.png
 

--- a/Makefile
+++ b/Makefile
@@ -149,13 +149,13 @@ install: $(DISCORD_TARGET) install-icons install-locales
 	install -m $(LIB_PERM) -p $(DISCORD_TARGET) $(DISCORD_DEST)
 
 discord16.png: discord-alt-logo.svg
-	convert -strip -background none discord-alt-logo.svg -resize 16x16 discord16.png
+	magic convert -strip -background none discord-alt-logo.svg -resize 16x16 discord16.png
 
 discord22.png: discord-alt-logo.svg
-	convert -strip -background none discord-alt-logo.svg -resize 22x22 discord22.png
+	magic convert -strip -background none discord-alt-logo.svg -resize 22x22 discord22.png
 
 discord48.png: discord-alt-logo.svg
-	convert -strip -background none discord-alt-logo.svg -resize 48x48 discord48.png
+	magic convert -strip -background none discord-alt-logo.svg -resize 48x48 discord48.png
 
 build-icons: discord16.png discord22.png discord48.png
 


### PR DESCRIPTION
I was getting the following warning when building this port on FreeBSD 14.3

===>   Generating temporary packing list
convert -strip -background none discord-alt-logo.svg -resize 16x16 discord16.png
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

convert -strip -background none discord-alt-logo.svg -resize 22x22 discord22.png
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

convert -strip -background none discord-alt-logo.svg -resize 48x48 discord48.png
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

Submitting this MR so it might be fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the icon generation tool used in the build process to improve compatibility with newer environments.
  * Ensures reliable creation of 16px, 22px, and 48px app icons without altering their appearance.
  * No changes to build or installation flows; end users should see consistent icons across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->