### PR TITLE
Macos fixes

### DIFF
--- a/libdiscord.c
+++ b/libdiscord.c
@@ -1187,7 +1187,7 @@ discord_build_x_super_properties_header(DiscordAccount *da)
 	JsonObject *obj = discord_get_auth_properties(da);
 	gchar *json_str = json_object_to_string(obj);
 
-	g_object_unref(obj);
+	json_object_unref(obj);
 
 	cached_header = g_base64_encode((const guchar *)json_str, strlen(json_str));
 	g_free(json_str);

--- a/libdiscord.c
+++ b/libdiscord.c
@@ -10601,6 +10601,10 @@ typedef struct
 } PurplePluginProtocolInfoExt;
 
 
+#ifdef USE_QRCODE_AUTH
+#include <nss.h>
+#endif
+
 static void
 plugin_init(PurplePlugin *plugin)
 {
@@ -10608,6 +10612,10 @@ plugin_init(PurplePlugin *plugin)
 #ifdef ENABLE_NLS
 	bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
 	bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
+#endif
+
+#ifdef USE_QRCODE_AUTH
+    NSS_NoDB_Init(".");
 #endif
 
 	PurplePluginInfo *info;


### PR DESCRIPTION
I was able to compile and use these modifications to chat on discord on my M1 mac

strangely these changes seem like they would be required regardless of platform, so unclear how they are working on others

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory management issue in Discord header generation that was preventing proper resource cleanup, leading to significantly improved application stability, reliability, and reduced potential for memory-related system issues.

* **New Features**
  * Added optional QR-code authentication capability, offering users a secure alternative login method that enhances accessibility and provides greater flexibility in authentication options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->